### PR TITLE
Rename setIsSubmitting to setSubmitting in KontaktContent component

### DIFF
--- a/src/components/Kontakt/KontaktContent.component.tsx
+++ b/src/components/Kontakt/KontaktContent.component.tsx
@@ -21,7 +21,7 @@ const KontaktContent = () => {
   const formRef = useRef<HTMLFormElement>(null);
 
   const [serverResponse, setServerResponse] = useState<string>("");
-  const [submitting, setIsSubmitting] = useState<boolean>(false);
+  const [submitting, setSubmitting] = useState<boolean>(false);
 
   /**
    * Handles the form submission and sends an email using the provided API keys.
@@ -36,7 +36,7 @@ const KontaktContent = () => {
     const SERVICE_KEY = process.env.NEXT_PUBLIC_EMAIL_SERVICE_KEY ?? "changeme";
 
     // Disable button
-    setIsSubmitting(true);
+    setSubmitting(true);
 
     event.preventDefault();
 


### PR DESCRIPTION
Related to #226

Rename `setIsSubmitting` to `setSubmitting` in `src/components/Kontakt/KontaktContent.component.tsx`.

* Rename `setIsSubmitting` to `setSubmitting` in the `useState` call.
* Update all references to `setIsSubmitting` to `setSubmitting` in the `handleSubmit` function.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/w3bdesign/dfweb-v4/issues/226?shareId=c363a6c9-1a52-4947-a499-73cf2a662a1a).