### PR TITLE
Create reusable GenericForm component

### DIFF
--- a/src/components/Kontakt/KontaktContent.component.tsx
+++ b/src/components/Kontakt/KontaktContent.component.tsx
@@ -9,7 +9,7 @@ import GenericForm from "@/components/UI/GenericForm.component";
 
 const formSchema = z.object({
   navn: z.string().min(1, "Fullt navn er påkrevd").regex(/^[a-zA-ZæøåÆØÅ ]+$/, "Vennligst bruk norske bokstaver"),
-  telefon: z.string().min(1, "Telefonnummer er påkrevd").regex(/^[0-9]{8}$/, "Vennligst oppgi et gyldig telefonnummer"),
+  telefon: z.string().min(1, "Telefonnummer er påkrevd").regex(/^\d{8}$/, "Vennligst oppgi et gyldig telefonnummer"),
   tekst: z.string().min(1, "Beskjed er påkrevd"),
 });
 
@@ -54,7 +54,7 @@ const KontaktContent = () => {
     {
       name: "telefon" as const,
       label: "Telefonnummer",
-      inputPattern: /^[0-9]{8}$/,
+      inputPattern: /^\d{8}$/,
       title: "Vennligst oppgi et gyldig telefonnummer",
     },
     {

--- a/src/components/Kontakt/KontaktContent.component.tsx
+++ b/src/components/Kontakt/KontaktContent.component.tsx
@@ -60,7 +60,7 @@ const KontaktContent = () => {
     {
       name: "tekst" as const,
       label: "Hva ønsker du å si?",
-      type: "textarea",
+      type: "textarea" as const,
     },
   ];
 

--- a/src/components/Kontakt/KontaktContent.component.tsx
+++ b/src/components/Kontakt/KontaktContent.component.tsx
@@ -1,14 +1,11 @@
 "use client";
 
-import { useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import emailjs from "@emailjs/browser";
 import { useState } from "react";
 
-import Button from "@/components/UI/Button.component";
 import PageHeader from "@/components/UI/PageHeader.component";
-import InputField from "@/components/UI/InputField.component";
+import GenericForm from "@/components/UI/GenericForm.component";
 
 const formSchema = z.object({
   navn: z.string().min(1, "Fullt navn er påkrevd").regex(/^[a-zA-ZæøåÆØÅ ]+$/, "Vennligst bruk norske bokstaver"),
@@ -25,15 +22,6 @@ type FormData = z.infer<typeof formSchema>;
  */
 
 const KontaktContent = () => {
-  const {
-    register,
-    handleSubmit,
-    formState: { errors, isSubmitting },
-    reset,
-  } = useForm<FormData>({
-    resolver: zodResolver(formSchema),
-  });
-
   const [serverResponse, setServerResponse] = useState<string>("");
 
   /**
@@ -51,11 +39,30 @@ const KontaktContent = () => {
       emailjs.init(EMAIL_API_KEY);
       await emailjs.send(SERVICE_KEY, TEMPLATE_KEY, data);
       setServerResponse("Takk for din beskjed");
-      reset();
     } catch (error) {
       setServerResponse("Feil under sending av skjema");
     }
   };
+
+  const formFields = [
+    {
+      name: "navn" as const,
+      label: "Fullt navn",
+      inputPattern: /^[a-zA-ZæøåÆØÅ ]+$/,
+      title: "Vennligst bruk norske bokstaver",
+    },
+    {
+      name: "telefon" as const,
+      label: "Telefonnummer",
+      inputPattern: /^[0-9]{8}$/,
+      title: "Vennligst oppgi et gyldig telefonnummer",
+    },
+    {
+      name: "tekst" as const,
+      label: "Hva ønsker du å si?",
+      type: "textarea",
+    },
+  ];
 
   return (
     <main data-testid="kontaktcontent" id="maincontent">
@@ -70,55 +77,12 @@ const KontaktContent = () => {
                     {serverResponse}
                   </h3>
                 ) : (
-                  <form
-                    id="contact-form"
-                    className="text-center"
-                    onSubmit={handleSubmit(onSubmit)}
-                    method="POST"
-                    action="/api/form"
-                    aria-label="Contact Form"
-                  >
-                    <fieldset>
-                      <legend className="text-center mx-auto text-xl mt-4 sr-only">
-                        Kontaktskjema
-                      </legend>
-                      <InputField<FormData>
-                        name="navn"
-                        label="Fullt navn"
-                        htmlFor="navn"
-                        register={register}
-                        error={errors.navn?.message}
-                        isRequired
-                        inputPattern={/^[a-zA-ZæøåÆØÅ ]+$/}
-                        title="Vennligst bruk norske bokstaver"
-                      />
-                      <br />
-                      <InputField<FormData>
-                        name="telefon"
-                        label="Telefonnummer"
-                        htmlFor="telefon"
-                        register={register}
-                        error={errors.telefon?.message}
-                        isRequired
-                        inputPattern={/^[0-9]{8}$/}
-                        title="Vennligst oppgi et gyldig telefonnummer"
-                      />
-                      <br />
-                      <InputField<FormData>
-                        name="tekst"
-                        type="textarea"
-                        label="Hva ønsker du å si?"
-                        htmlFor="tekst"
-                        register={register}
-                        error={errors.tekst?.message}
-                        isRequired
-                      />
-                      <br />
-                    </fieldset>
-                    <div className="-mt-4">
-                      <Button disabled={isSubmitting}>Send skjema</Button>
-                    </div>
-                  </form>
+                  <GenericForm<typeof formSchema>
+                    formSchema={formSchema}
+                    onSubmit={onSubmit}
+                    fields={formFields}
+                    submitButtonText="Send skjema"
+                  />
                 )}
               </div>
             </div>

--- a/src/components/UI/GenericForm.component.tsx
+++ b/src/components/UI/GenericForm.component.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import Button from './Button.component';
+import InputField from './InputField.component';
+
+interface GenericFormProps<T extends z.ZodType<any, any>> {
+  formSchema: T;
+  onSubmit: (data: z.infer<T>) => Promise<void>;
+  fields: Array<{
+    name: keyof z.infer<T>;
+    label: string;
+    type?: string;
+    inputPattern?: RegExp;
+    title?: string;
+  }>;
+  submitButtonText: string;
+}
+
+function GenericForm<T extends z.ZodType<any, any>>({
+  formSchema,
+  onSubmit,
+  fields,
+  submitButtonText,
+}: GenericFormProps<T>) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<z.infer<T>>({
+    resolver: zodResolver(formSchema),
+  });
+
+  return (
+    <form
+      id="contact-form"
+      className="text-center"
+      onSubmit={handleSubmit(onSubmit)}
+      method="POST"
+      action="/api/form"
+      aria-label="Contact Form"
+    >
+      <fieldset>
+        <legend className="text-center mx-auto text-xl mt-4 sr-only">
+          Kontaktskjema
+        </legend>
+        {fields.map((field) => (
+          <React.Fragment key={field.name.toString()}>
+            <InputField<z.infer<T>>
+              name={field.name}
+              label={field.label}
+              htmlFor={field.name.toString()}
+              register={register}
+              error={errors[field.name]?.message?.toString()}
+              isRequired
+              type={field.type}
+              inputPattern={field.inputPattern}
+              title={field.title}
+            />
+            <br />
+          </React.Fragment>
+        ))}
+      </fieldset>
+      <div className="-mt-4">
+        <Button disabled={isSubmitting}>{submitButtonText}</Button>
+      </div>
+    </form>
+  );
+}
+
+export default GenericForm;

--- a/src/components/UI/GenericForm.component.tsx
+++ b/src/components/UI/GenericForm.component.tsx
@@ -22,6 +22,14 @@ interface GenericFormProps<TSchema extends z.ZodType<FieldValues>> {
   readonly submitButtonText: string;
 }
 
+/**
+ * A generic, reusable form component that can be easily customized and extended.
+ * It uses Zod for schema validation and react-hook-form for form handling.
+ * 
+ * @template TSchema - The Zod schema type for form validation.
+ * @param {Readonly<GenericFormProps<TSchema>>} props - The props for the GenericForm component.
+ * @returns {JSX.Element} The rendered form.
+ */
 function GenericForm<TSchema extends z.ZodType<FieldValues>>({
   formSchema,
   onSubmit,

--- a/src/components/UI/GenericForm.component.tsx
+++ b/src/components/UI/GenericForm.component.tsx
@@ -8,18 +8,18 @@ import InputField from './InputField.component';
 type InputType = 'input' | 'textarea';
 
 type FieldConfig<T extends FieldValues> = {
-  name: Path<T>;
-  label: string;
-  type?: InputType;
-  inputPattern?: RegExp;
-  title?: string;
+  readonly name: Path<T>;
+  readonly label: string;
+  readonly type?: InputType;
+  readonly inputPattern?: RegExp;
+  readonly title?: string;
 };
 
 interface GenericFormProps<TSchema extends z.ZodType<FieldValues>> {
-  formSchema: TSchema;
-  onSubmit: (data: z.infer<TSchema>) => Promise<void>;
-  fields: FieldConfig<z.infer<TSchema>>[];
-  submitButtonText: string;
+  readonly formSchema: TSchema;
+  readonly onSubmit: (data: z.infer<TSchema>) => Promise<void>;
+  readonly fields: ReadonlyArray<FieldConfig<z.infer<TSchema>>>;
+  readonly submitButtonText: string;
 }
 
 function GenericForm<TSchema extends z.ZodType<FieldValues>>({
@@ -27,7 +27,7 @@ function GenericForm<TSchema extends z.ZodType<FieldValues>>({
   onSubmit,
   fields,
   submitButtonText,
-}: GenericFormProps<TSchema>) {
+}: Readonly<GenericFormProps<TSchema>>) {
   type FormData = z.infer<TSchema>;
 
   const {

--- a/src/components/UI/GenericForm.component.tsx
+++ b/src/components/UI/GenericForm.component.tsx
@@ -1,36 +1,40 @@
 import React from 'react';
-import { useForm, Path, UseFormRegister, FieldValues } from 'react-hook-form';
+import { useForm, Path, FieldValues } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import Button from './Button.component';
 import InputField from './InputField.component';
 
+type InputType = 'input' | 'textarea';
+
 type FieldConfig<T extends FieldValues> = {
   name: Path<T>;
   label: string;
-  type?: string;
+  type?: InputType;
   inputPattern?: RegExp;
   title?: string;
 };
 
-interface GenericFormProps<T extends z.ZodType<any, any>> {
-  formSchema: T;
-  onSubmit: (data: z.infer<T>) => Promise<void>;
-  fields: FieldConfig<z.infer<T>>[];
+interface GenericFormProps<TSchema extends z.ZodType<FieldValues>> {
+  formSchema: TSchema;
+  onSubmit: (data: z.infer<TSchema>) => Promise<void>;
+  fields: FieldConfig<z.infer<TSchema>>[];
   submitButtonText: string;
 }
 
-function GenericForm<T extends z.ZodType<any, any>>({
+function GenericForm<TSchema extends z.ZodType<FieldValues>>({
   formSchema,
   onSubmit,
   fields,
   submitButtonText,
-}: GenericFormProps<T>) {
+}: GenericFormProps<TSchema>) {
+  type FormData = z.infer<TSchema>;
+
   const {
     register,
     handleSubmit,
     formState: { errors, isSubmitting },
-  } = useForm<z.infer<T>>({
+  } = useForm<FormData>({
     resolver: zodResolver(formSchema),
   });
 
@@ -49,12 +53,12 @@ function GenericForm<T extends z.ZodType<any, any>>({
         </legend>
         {fields.map((field) => (
           <React.Fragment key={field.name}>
-            <InputField<z.infer<T>>
+            <InputField<FormData>
               name={field.name}
               label={field.label}
               htmlFor={field.name}
-              register={register as UseFormRegister<z.infer<T>>}
-              error={errors[field.name]?.message?.toString()}
+              register={register}
+              error={errors[field.name]?.message as string | undefined}
               isRequired
               type={field.type}
               inputPattern={field.inputPattern}

--- a/src/components/UI/GenericForm.component.tsx
+++ b/src/components/UI/GenericForm.component.tsx
@@ -1,20 +1,22 @@
 import React from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, Path, UseFormRegister, FieldValues } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import Button from './Button.component';
 import InputField from './InputField.component';
 
+type FieldConfig<T extends FieldValues> = {
+  name: Path<T>;
+  label: string;
+  type?: string;
+  inputPattern?: RegExp;
+  title?: string;
+};
+
 interface GenericFormProps<T extends z.ZodType<any, any>> {
   formSchema: T;
   onSubmit: (data: z.infer<T>) => Promise<void>;
-  fields: Array<{
-    name: keyof z.infer<T>;
-    label: string;
-    type?: string;
-    inputPattern?: RegExp;
-    title?: string;
-  }>;
+  fields: FieldConfig<z.infer<T>>[];
   submitButtonText: string;
 }
 
@@ -46,12 +48,12 @@ function GenericForm<T extends z.ZodType<any, any>>({
           Kontaktskjema
         </legend>
         {fields.map((field) => (
-          <React.Fragment key={field.name.toString()}>
+          <React.Fragment key={field.name}>
             <InputField<z.infer<T>>
               name={field.name}
               label={field.label}
-              htmlFor={field.name.toString()}
-              register={register}
+              htmlFor={field.name}
+              register={register as UseFormRegister<z.infer<T>>}
               error={errors[field.name]?.message?.toString()}
               isRequired
               type={field.type}

--- a/src/components/UI/InputField.component.tsx
+++ b/src/components/UI/InputField.component.tsx
@@ -10,7 +10,7 @@ export interface InputProps<T extends FieldValues> {
   title?: string;
   type?: "input" | "textarea";
   register: UseFormRegister<T>;
-  error?: string;
+  error?: string | undefined;
 }
 
 export function createRegisterOptions<T extends FieldValues>(

--- a/src/components/UI/InputField.component.tsx
+++ b/src/components/UI/InputField.component.tsx
@@ -10,7 +10,7 @@ export interface InputProps<T extends FieldValues> {
   title?: string;
   type?: "input" | "textarea";
   register: UseFormRegister<T>;
-  error?: string | undefined;
+  error?: string;
 }
 
 export function createRegisterOptions<T extends FieldValues>(


### PR DESCRIPTION
- Extract form logic from KontaktContent into a new GenericForm component
- Implement type-safe props with readonly modifiers for immutability
- Add Zod schema validation integration
- Update regular expressions for improved readability
- Add concise JSDoc documentation for better developer experience

This refactoring improves code reusability, maintainability, and type safety
across the application. The GenericForm component can now be easily used in
other parts of the application, reducing duplication and standardizing form
handling.