### PR TITLE
Make screenshots visible automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,20 +21,11 @@ Fourth version of my personal portfolio website with Next.js, Framer Motion, San
 
 ## 🌐 Live URL: <https://www.dfweb.no>
 
-<details>
-  <summary>Frontend</summary>
-  <img src="https://github.com/user-attachments/assets/958aaa13-0f82-405d-b1d2-ff99588cf7c4" alt="Frontend Image" />
-</details>
+<img src="https://github.com/user-attachments/assets/958aaa13-0f82-405d-b1d2-ff99588cf7c4" alt="Frontend Image" />
 
-<details>
-  <summary>Backend</summary>
-  <img src="https://github.com/user-attachments/assets/67099a89-0cda-458a-9fcd-ab09b016ace4" alt="Backend Image" />
-</details>
+<img src="https://github.com/user-attachments/assets/67099a89-0cda-458a-9fcd-ab09b016ace4" alt="Backend Image" />
 
-<details>
-  <summary>Google Lighthouse</summary>
-  <img src="https://github.com/user-attachments/assets/56616d37-be9f-4459-91f0-6906b189bd1b" alt="Google Lighthouse Image" />
-</details>
+<img src="https://github.com/user-attachments/assets/56616d37-be9f-4459-91f0-6906b189bd1b" alt="Google Lighthouse Image" />
 
 ## 🚀 Features
 


### PR DESCRIPTION
Fixes #294

Make screenshots in `README.md` visible by default.

* Remove `<details>` and `<summary>` tags enclosing the screenshots.
* Embed screenshots directly using `<img>` tags.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/w3bdesign/dfweb-v4/issues/294?shareId=b414a474-77e3-41a0-ac2d-a5fdfc3234b3).