### PR TITLE
Add spacing between screenshots in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Fourth version of my personal portfolio website with Next.js, Framer Motion, San
 ## 🌐 Live URL: <https://www.dfweb.no>
 
 <img src="https://github.com/user-attachments/assets/958aaa13-0f82-405d-b1d2-ff99588cf7c4" alt="Frontend Image" />
-
+<br>
 <img src="https://github.com/user-attachments/assets/67099a89-0cda-458a-9fcd-ab09b016ace4" alt="Backend Image" />
-
+<br>
 <img src="https://github.com/user-attachments/assets/56616d37-be9f-4459-91f0-6906b189bd1b" alt="Google Lighthouse Image" />
 
 ## 🚀 Features


### PR DESCRIPTION
Related to #296

Add visual separation between screenshots in `README.md`.

* Add `<br>` tags between the screenshot images to provide visual separation.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/w3bdesign/dfweb-v4/issues/296?shareId=baf18080-9ffc-4689-958c-18a9f99ebd1f).