### PR TITLE
Add links to table of contents in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@
 Fourth version of my personal portfolio website with Next.js, Framer Motion, Sanity.io and Typescript.
 
 ## 📋 Table of Contents
-- Live URL
-- Frontend
-- Backend
-- Google Lighthouse
-- Features
-  - General
-  - Design
-  - Accessibility
-  - Devops / Code quality
+- [Live URL](#live-url)
+- [Frontend](#frontend)
+- [Backend](#backend)
+- [Google Lighthouse](#google-lighthouse)
+- [Features](#features)
+  - [General](#general)
+  - [Design](#design)
+  - [Accessibility](#accessibility)
+  - [Devops / Code quality](#devops--code-quality)
 
 ## 🌐 Live URL: <https://www.dfweb.no>
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/8d5cae5017b1a9698843/maintainability)](https://codeclimate.com/github/w3bdesign/dfweb-v4/maintainability)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=w3bdesign_dfweb-v4&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=w3bdesign_dfweb-v4)
  
-# Dfwebno Portfolio Version 4
+# Dfweb.no Portfolio Version 4
 
 Fourth version of my personal portfolio website with Next.js, Framer Motion, Sanity.io and Typescript.
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/8d5cae5017b1a9698843/maintainability)](https://codeclimate.com/github/w3bdesign/dfweb-v4/maintainability)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=w3bdesign_dfweb-v4&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=w3bdesign_dfweb-v4)
  
-# 👨‍💻 Dfweb.no Portfolio Version 4
+# Dfwebno Portfolio Version 4
 
 Fourth version of my personal portfolio website with Next.js, Framer Motion, Sanity.io and Typescript.
 
-## 📋 Table of Contents
+## Table of Contents
 - [Live URL](#live-url)
 - [Frontend](#frontend)
 - [Backend](#backend)
@@ -17,29 +17,31 @@ Fourth version of my personal portfolio website with Next.js, Framer Motion, San
   - [General](#general)
   - [Design](#design)
   - [Accessibility](#accessibility)
-  - [Devops Code quality](#devops-code-quality)
+  - [Devops and Code quality](#devops-and-code-quality)
 
-## 🌐 Live URL: <https://www.dfweb.no>
+## Live URL
 
-### Frontend
+https://www.dfweb.no
+
+## Frontend
 
 <img src="https://github.com/user-attachments/assets/958aaa13-0f82-405d-b1d2-ff99588cf7c4" alt="Frontend Image" />
 
 * * *
 
-### Sanity backend
+## Backend
 
 <img src="https://github.com/user-attachments/assets/67099a89-0cda-458a-9fcd-ab09b016ace4" alt="Backend Image" />
 
 * * *
 
-### Google Lighthouse
+## Google Lighthouse
 
 <img src="https://github.com/user-attachments/assets/56616d37-be9f-4459-91f0-6906b189bd1b" alt="Google Lighthouse Image" />
 
-## 🚀 Features
+## Features
 
-### 🌟 General
+### General
 
 - Clean, modern, responsive and Matrix-inspired design
 - Components are 100% typescript
@@ -59,20 +61,20 @@ Fourth version of my personal portfolio website with Next.js, Framer Motion, San
 - React Hook Form with Typescript and Zod for efficient form handling and validation
 - Reusable GenericForm component for easy form creation and management
 
-### 🎨 Design
+### Design
 
 - Fully responsive design tested on all devices
 - React Icons for project icons
 - Tailwind CSS for styling
 - Animated reusable input fields
 
-### ♿ Accessibility
+### Accessibility
 
 - WCAG accessibility tested
 - Accessibility testing with Cypress Axe
 - Builds will fail if any a11y errors are found
 
-### 🛠️ Devops Code quality
+### Devops and Code quality
 
 - Continuous Integration with CircleCI
 - CircleCI will warn before deploy if tests fail (setup for React testing library)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Fourth version of my personal portfolio website with Next.js, Framer Motion, San
 
 ## Live URL
 
-https://www.dfweb.no
+<https://www.dfweb.no/>
 
 ## Frontend
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Fourth version of my personal portfolio website with Next.js, Framer Motion, San
   - [General](#general)
   - [Design](#design)
   - [Accessibility](#accessibility)
-  - [Devops / Code quality](#devops--code-quality)
+  - [Devops Code quality](#devops-code-quality)
 
 ## 🌐 Live URL: <https://www.dfweb.no>
 
@@ -72,7 +72,7 @@ Fourth version of my personal portfolio website with Next.js, Framer Motion, San
 - Accessibility testing with Cypress Axe
 - Builds will fail if any a11y errors are found
 
-### 🛠️ Devops / Code quality
+### 🛠️ Devops Code quality
 
 - Continuous Integration with CircleCI
 - CircleCI will warn before deploy if tests fail (setup for React testing library)


### PR DESCRIPTION
Fixes #298

Add links to the table of contents in `README.md`.

* **Table of Contents**
  - Add links to "Live URL", "Frontend", "Backend", "Google Lighthouse", and "Features" sections.
  - Add links to subsections "General", "Design", "Accessibility", and "Devops / Code quality" under "Features".

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/w3bdesign/dfweb-v4/issues/298?shareId=ac11b1ec-cf4c-4dee-babc-7d05c7c47436).