### PR TITLE
Add Jsdoc to MatrixCursor component

### DIFF
--- a/src/components/Animations/MatrixCursor.component.tsx
+++ b/src/components/Animations/MatrixCursor.component.tsx
@@ -19,6 +19,12 @@ interface MatrixTrail {
   char: string;
 }
 
+/**
+ * MatrixCursor component that renders a custom cursor with a matrix trail effect
+ * @param {MatrixCursorProps} props - The props for the MatrixCursor component
+ * @param {RefObject<HTMLElement>} props.heroRef - Reference to the hero section element
+ * @returns {JSX.Element | null} The rendered MatrixCursor component or null if heroRef is not available
+ */
 const MatrixCursor = ({ heroRef }: MatrixCursorProps) => {
   const [cursorPosition, setCursorPosition] = useState({ x: 0, y: 0 });
   const [isHovered, setIsHovered] = useState(false);


### PR DESCRIPTION
Fixes #477

Add Jsdoc comments to the `MatrixCursor` function declaration in `src/components/Animations/MatrixCursor.component.tsx`.

* Add Jsdoc comment for `MatrixCursor` function declaration
* Include descriptions for the function, parameters, and return type

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/w3bdesign/dfweb-v4/pull/478?shareId=e66c38fd-e70a-4d31-9a56-e192710c9792).