### PR TITLE
Refactor Groq queries

### DIFF
--- a/src/app/RootLayout.tsx
+++ b/src/app/RootLayout.tsx
@@ -1,20 +1,7 @@
-import { groq } from "next-sanity";
 import { client } from "@/lib/sanity/client";
 import Header from "@/components/Layout/Header.component";
 import ErrorBoundary from "@/components/ErrorBoundary/ErrorBoundary";
-
-const navigationQuery = groq`
-  *[_type == "navigation"][0] {
-    title,
-    links[] {
-      title,
-      name,
-      hash,
-      href,
-      externalLink
-    }
-  }
-`;
+import { navigationQuery } from "@/lib/sanity/queries";
 
 export default async function RootLayout({
   children,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
-import { groq } from "next-sanity";
 import dynamic from "next/dynamic";
 import RootLayout from "@/app/RootLayout";
 import { client } from "@/lib/sanity/client";
+import { pageContentQuery } from "@/lib/sanity/queries";
 
 const DynamicHero = dynamic(() => import("@/components/Index/Hero.component"), {
   loading: () => <div>Loading hero...</div>,
@@ -15,15 +15,6 @@ const DynamicIndexContent = dynamic(
 );
 
 export default async function HomePage() {
-  const pageContentQuery = groq`
-    *[_type == 'page' && title match 'Hjem'][0]{
-      "id": _id, 
-      title, 
-      hero, 
-      content
-    }
-  `;
-
   const pageContent = await client.fetch(pageContentQuery);
 
   return (

--- a/src/app/prosjekter/page.tsx
+++ b/src/app/prosjekter/page.tsx
@@ -3,6 +3,7 @@ import PageHeader from "@/components/UI/PageHeader.component";
 import ProsjektCard from "@/components/Prosjekter/ProsjektCard.component";
 
 import { client } from "@/lib/sanity/client";
+import { projectsQuery } from "@/lib/sanity/queries";
 
 import type { Project } from "@/types/sanity.types";
 import type { Metadata } from "next/types";
@@ -11,18 +12,6 @@ export const metadata: Metadata = {
   title: "Prosjekter - Dfweb",
   description: "Daniel Fjeldstad | Frontend Web Utvikler | Portefølje",
 };
-
-const projectsQuery = `*[_type == "project"] | order(featured desc, featureOrder asc, _createdAt desc) {
-  id,
-  name,
-  description,
-  subdescription,
-  projectimage,
-  urlwww,
-  urlgithub,
-  featured,
-  featureOrder
-}`;
 
 export default async function Prosjekter() {
   const posts: Project[] = await client.fetch(projectsQuery);

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -39,3 +39,25 @@ export const cvQuery = groq`
     }
   }
 `;
+
+export const pageContentQuery = groq`
+  *[_type == 'page' && title match 'Hjem'][0]{
+    "id": _id, 
+    title, 
+    hero, 
+    content
+  }
+`;
+
+export const navigationQuery = groq`
+  *[_type == "navigation"][0] {
+    title,
+    links[] {
+      title,
+      name,
+      hash,
+      href,
+      externalLink
+    }
+  }
+`;


### PR DESCRIPTION
Fixes #507

Refactor Groq queries to a separate file and update imports.

* Add `pageContentQuery` and `navigationQuery` to `src/lib/sanity/queries.ts`.
* Remove `pageContentQuery` from `src/app/page.tsx` and import it from `src/lib/sanity/queries.ts`.
* Remove `projectsQuery` from `src/app/prosjekter/page.tsx` and import it from `src/lib/sanity/queries.ts`.
* Remove `navigationQuery` from `src/app/RootLayout.tsx` and import it from `src/lib/sanity/queries.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/w3bdesign/dfweb-v4/pull/508?shareId=d8aea37c-756b-457f-af63-e72b8df16749).