### PR TITLE
📦 deps: update sanity and react types dependencies

### DIFF
--- a/studio/package.json
+++ b/studio/package.json
@@ -17,12 +17,12 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.4.0",
-    "sanity": "^3.66.0",
+    "sanity": "^3.66.1",
     "styled-components": "^6.1.13"
   },
   "devDependencies": {
     "@sanity/eslint-config-studio": "^4.0.0",
-    "@types/react": "^18.3.13",
+    "@types/react": "^18.3.14",
     "eslint": "^9.16.0",
     "prettier": "^3.4.2",
     "typescript": "^5.7.2"


### PR DESCRIPTION
Updates sanity from 3.66.0 to 3.66.1 and @types/react from 18.3.13 to 18.3.14 to ensure latest bug fixes and type definitions are included