### PR TITLE
♻️ refactor: enhance CV schema with preview configuration

### DIFF
--- a/studio/schemaTypes/documents/cv.ts
+++ b/studio/schemaTypes/documents/cv.ts
@@ -1,7 +1,25 @@
+interface PreviewSelection {
+  keyQualifications?: string[]
+}
+
 export default {
   name: 'cv',
   title: 'CV',
   type: 'document',
+  preview: {
+    select: {
+      keyQualifications: 'keyQualifications'
+    },
+    prepare(selection: PreviewSelection) {
+      const { keyQualifications } = selection
+      const mainQualification = keyQualifications?.[0] || 'No qualifications added'
+      
+      return {
+        title: 'CV',
+        subtitle: mainQualification
+      }
+    }
+  },
   fields: [
     {
       name: 'keyQualifications',


### PR DESCRIPTION
Add document preview functionality to CV schema to display first qualification as subtitle for better content visibility in the studio interface