### PR TITLE
Disable animated cursor on mobile

### DIFF
--- a/src/components/Animations/MatrixCursor.component.tsx
+++ b/src/components/Animations/MatrixCursor.component.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, RefObject, useState, useCallback } from "react";
 import "../../app/cursor.css";
+import { useMobile } from "../../hooks/useMobile"; // Pb51b
 
 interface MatrixCursorProps {
   heroRef: RefObject<HTMLElement | null>;
@@ -26,6 +27,7 @@ interface MatrixTrail {
  * @returns {JSX.Element | null} The rendered MatrixCursor component or null if heroRef is not available
  */
 const MatrixCursor = ({ heroRef }: MatrixCursorProps) => {
+  const isMobile = useMobile(); // Pd528
   const [cursorPosition, setCursorPosition] = useState({ x: 0, y: 0 });
   const [isHovered, setIsHovered] = useState(false);
   const [trails, setTrails] = useState<MatrixTrail[]>([]);
@@ -103,7 +105,7 @@ const MatrixCursor = ({ heroRef }: MatrixCursorProps) => {
     );
   }, []);
 
-  if (!heroRef.current) return null;
+  if (!heroRef.current || isMobile) return null; // P6ecf
 
   const cursorStyles: CursorStyles = {
     position: "fixed",

--- a/src/hooks/useMobile.tsx
+++ b/src/hooks/useMobile.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 
+// Hook to detect if the device is mobile based on window width
 export function useMobile(): boolean {
   const [isMobile, setIsMobile] = useState<boolean>(false);
 


### PR DESCRIPTION
Fixes #567

Disable animated cursor on mobile devices.

* Import the `useMobile` hook in `src/components/Animations/MatrixCursor.component.tsx`.
* Add a `const isMobile = useMobile();` line in the `MatrixCursor` component.
* Add a condition to return `null` if `isMobile` is `true` in the `MatrixCursor` component.
* Add a comment explaining the purpose of the `useMobile` hook in `src/hooks/useMobile.tsx`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/w3bdesign/dfweb-v4/pull/568?shareId=ab9180d6-09d0-4884-9a2a-1ccb4eb7522c).