### PR TITLE
💄 ui: add responsive class to hide download button on desktop

### DIFF
--- a/src/components/CV/CVContent.component.tsx
+++ b/src/components/CV/CVContent.component.tsx
@@ -112,7 +112,7 @@ const CVContent: React.FC<CVContentProps> = ({ cvData }) => {
                 <div className="md:flex md:justify-center hidden">
                   <Tabs tabs={tabs} />
                 </div>
-                <div className="mx-auto text-center md:mt-8">
+                <div className="mx-auto text-center md:mt-8 md:hidden">
                   <Button href="./cv.pdf" renderAs="a" type="button">
                     Last ned PDF
                   </Button>


### PR DESCRIPTION
The download PDF button should only be visible on mobile devices since the CV component has tabs for navigation on desktop view. This improves UI consistency.