### PR TITLE
🔥 cleanup: remove cv.pdf link

### DIFF
--- a/cypress/e2e/cv.cy.ts
+++ b/cypress/e2e/cv.cy.ts
@@ -12,7 +12,6 @@ describe("Test at CV vises og laster", () => {
   it("Se at CV vises", () => {
     cy.get("main#maincontent").should("be.visible");
     cy.get("#tab-qualifications").should("have.length", 1).and("be.visible");
-    cy.get('a[href="./cv.pdf"]').should("be.visible");
   });
 
   it("CV skal ikke ha noen a11y feilmeldinger", () => {


### PR DESCRIPTION
Removed link to CV PDF file as it's no longer needed in the test suite. The link is being removed since we want to focus on the main CV content.