### PR TITLE
🔒 security: update frame-ancestors and X-Frame-Options headers

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,7 +9,7 @@ const cspDirectives = {
   'object-src': ["'none'"],
   'base-uri': ["'self'"],
   'form-action': ["'self'"],
-  'frame-ancestors': ["'none'"],
+  'frame-ancestors': ["'self'", "https://presentasjon.dfweb.no"],
   'connect-src': ["'self'", "https://api.emailjs.com", "https://va.vercel-scripts.com"],
 };
 
@@ -31,7 +31,7 @@ const nextConfig: NextConfig = {
     return [{
       source: "/:path*",
       headers: [
-        { key: "X-Frame-Options", value: "DENY" },
+        { key: "X-Frame-Options", value: "ALLOW-FROM https://presentasjon.dfweb.no" },
         { key: "X-Content-Type-Options", value: "nosniff" },
         { key: "Content-Security-Policy", value: buildCspHeader(cspDirectives) },
       ],


### PR DESCRIPTION
Allow embedding from presentasjon.dfweb.no domain while maintaining secure CSP and frame control policies for controlled content embedding