### PR TITLE
📝 docs(cv): update education timeframe to 2025

### DIFF
--- a/src/e2e/playwright/cv.spec.ts
+++ b/src/e2e/playwright/cv.spec.ts
@@ -32,7 +32,7 @@ test.describe("CV page", () => {
 
     // Check if education information is present
     await expect(page.getByLabel("Utdanning")).toContainText(
-      "2019 – 2024 - Kompetanseheving / egenlæring frontendutvikling",
+      "2019 – 2025 - Kompetanseheving / egenlæring frontendutvikling",
     );
   });
 });


### PR DESCRIPTION
Updated the end year of frontend development self-learning period from 2024 to 2025 to reflect current education timeline