### PR TITLE
👷 ci: add wait period before starting repomix workflow

### DIFF
--- a/.github/workflows/repomix.yml
+++ b/.github/workflows/repomix.yml
@@ -20,6 +20,11 @@ jobs:
         with:
           fetch-depth: 0 # fetch all history for better context
 
+      - name: Wait for other checks
+        run: |
+          echo "Waiting for 2 minutes to allow other checks to complete..."
+          sleep 120
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
This change introduces a 2-minute delay to ensure other checks have time to start running before the repomix workflow begins execution