### PR TITLE
✅ test: add testing library type definitions 

### DIFF
--- a/src/__tests__/Animations/BounceInScroll.test.tsx
+++ b/src/__tests__/Animations/BounceInScroll.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from "@testing-library/react";
-import { expect } from "@jest/globals";
 import "@testing-library/jest-dom";
 import BounceInScroll from "@/components/Animations/BounceInScroll.component";
 
@@ -28,7 +27,7 @@ describe("BounceInScroll", () => {
     );
 
     // Assert
-    expect(screen.getByText(testContent)).toBeTruthy();
+    expect(screen.getByText(testContent)).toBeInTheDocument();
   });
 
   it("applies custom CSS class", () => {
@@ -43,9 +42,7 @@ describe("BounceInScroll", () => {
     );
 
     // Assert
-    expect(
-      screen.getByTestId("bounceinscroll").classList.contains(testClass)
-    ).toBeTruthy();
+    expect(screen.getByTestId("bounceinscroll")).toHaveClass(testClass);
   });
 
   it("configures viewport with default amount when viewAmount not provided", () => {
@@ -61,8 +58,8 @@ describe("BounceInScroll", () => {
 
     // Assert
     const element = screen.getByTestId("bounceinscroll");
-    expect(element).toBeTruthy();
-    expect(screen.getByText(testContent)).toBeTruthy();
+    expect(element).toBeInTheDocument();
+    expect(screen.getByText(testContent)).toBeInTheDocument();
   });
 
   it("configures viewport with custom amount when viewAmount provided", () => {
@@ -79,8 +76,8 @@ describe("BounceInScroll", () => {
 
     // Assert
     const element = screen.getByTestId("bounceinscroll");
-    expect(element).toBeTruthy();
-    expect(screen.getByText(testContent)).toBeTruthy();
+    expect(element).toBeInTheDocument();
+    expect(screen.getByText(testContent)).toBeInTheDocument();
   });
 
   it("configures for instant animation when instant prop is true", () => {
@@ -96,8 +93,8 @@ describe("BounceInScroll", () => {
 
     // Assert
     const element = screen.getByTestId("bounceinscroll");
-    expect(element).toBeTruthy();
-    expect(screen.getByText(testContent)).toBeTruthy();
+    expect(element).toBeInTheDocument();
+    expect(screen.getByText(testContent)).toBeInTheDocument();
   });
 
   it("handles all viewport amount types", () => {
@@ -115,8 +112,8 @@ describe("BounceInScroll", () => {
 
       // Assert
       const element = screen.getByTestId("bounceinscroll");
-      expect(element).toBeTruthy();
-      expect(screen.getByText(testContent)).toBeTruthy();
+      expect(element).toBeInTheDocument();
+      expect(screen.getByText(testContent)).toBeInTheDocument();
 
       // Cleanup
       unmount();

--- a/src/__tests__/Animations/BounceInScroll.test.tsx
+++ b/src/__tests__/Animations/BounceInScroll.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import { expect } from "@jest/globals";
 import "@testing-library/jest-dom";
 import BounceInScroll from "@/components/Animations/BounceInScroll.component";
 
@@ -23,11 +24,11 @@ describe("BounceInScroll", () => {
     render(
       <BounceInScroll>
         <div>{testContent}</div>
-      </BounceInScroll>,
+      </BounceInScroll>
     );
 
     // Assert
-    expect(screen.getByText(testContent)).toBeInTheDocument();
+    expect(screen.getByText(testContent)).toBeTruthy();
   });
 
   it("applies custom CSS class", () => {
@@ -38,11 +39,13 @@ describe("BounceInScroll", () => {
     render(
       <BounceInScroll cssClass={testClass}>
         <div>Test content</div>
-      </BounceInScroll>,
+      </BounceInScroll>
     );
 
     // Assert
-    expect(screen.getByTestId("bounceinscroll")).toHaveClass(testClass);
+    expect(
+      screen.getByTestId("bounceinscroll").classList.contains(testClass)
+    ).toBeTruthy();
   });
 
   it("configures viewport with default amount when viewAmount not provided", () => {
@@ -53,13 +56,13 @@ describe("BounceInScroll", () => {
     render(
       <BounceInScroll>
         <div>{testContent}</div>
-      </BounceInScroll>,
+      </BounceInScroll>
     );
 
     // Assert
     const element = screen.getByTestId("bounceinscroll");
-    expect(element).toBeInTheDocument();
-    expect(screen.getByText(testContent)).toBeInTheDocument();
+    expect(element).toBeTruthy();
+    expect(screen.getByText(testContent)).toBeTruthy();
   });
 
   it("configures viewport with custom amount when viewAmount provided", () => {
@@ -71,13 +74,13 @@ describe("BounceInScroll", () => {
     render(
       <BounceInScroll viewAmount={viewAmount}>
         <div>{testContent}</div>
-      </BounceInScroll>,
+      </BounceInScroll>
     );
 
     // Assert
     const element = screen.getByTestId("bounceinscroll");
-    expect(element).toBeInTheDocument();
-    expect(screen.getByText(testContent)).toBeInTheDocument();
+    expect(element).toBeTruthy();
+    expect(screen.getByText(testContent)).toBeTruthy();
   });
 
   it("configures for instant animation when instant prop is true", () => {
@@ -88,13 +91,13 @@ describe("BounceInScroll", () => {
     render(
       <BounceInScroll instant={true}>
         <div>{testContent}</div>
-      </BounceInScroll>,
+      </BounceInScroll>
     );
 
     // Assert
     const element = screen.getByTestId("bounceinscroll");
-    expect(element).toBeInTheDocument();
-    expect(screen.getByText(testContent)).toBeInTheDocument();
+    expect(element).toBeTruthy();
+    expect(screen.getByText(testContent)).toBeTruthy();
   });
 
   it("handles all viewport amount types", () => {
@@ -107,13 +110,13 @@ describe("BounceInScroll", () => {
       const { unmount } = render(
         <BounceInScroll viewAmount={amount}>
           <div>{testContent}</div>
-        </BounceInScroll>,
+        </BounceInScroll>
       );
 
       // Assert
       const element = screen.getByTestId("bounceinscroll");
-      expect(element).toBeInTheDocument();
-      expect(screen.getByText(testContent)).toBeInTheDocument();
+      expect(element).toBeTruthy();
+      expect(screen.getByText(testContent)).toBeTruthy();
 
       // Cleanup
       unmount();

--- a/src/types/testing-library.d.ts
+++ b/src/types/testing-library.d.ts
@@ -1,0 +1,34 @@
+/// <reference types="jest" />
+/// <reference types="@testing-library/jest-dom" />
+
+// Extend Jest matchers
+declare namespace jest {
+  interface Matchers<R> {
+    toBeInTheDocument(): R;
+    toHaveTextContent(text: string): R;
+    toBeVisible(): R;
+    toBeDisabled(): R;
+    toBeEnabled(): R;
+    toHaveAttribute(attr: string, value?: string): R;
+    toHaveClass(className: string): R;
+    toHaveStyle(css: Record<string, any>): R;
+  }
+}
+
+// Augment Chai assertions for Cypress
+declare global {
+  namespace Chai {
+    interface Assertion {
+      toBeInTheDocument(): Assertion;
+      toHaveTextContent(text: string): Assertion;
+      toBeVisible(): Assertion;
+      toBeDisabled(): Assertion;
+      toBeEnabled(): Assertion;
+      toHaveAttribute(attr: string, value?: string): Assertion;
+      toHaveClass(className: string): Assertion;
+      toHaveStyle(css: Record<string, any>): Assertion;
+    }
+  }
+}
+
+export {};


### PR DESCRIPTION
Extend Jest and Chai matchers with custom assertions for DOM testing and
improve TypeScript support for testing utilities