### PR TITLE
🎨 style: rename accessibility tests workflow to a11y

### DIFF
--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -1,4 +1,4 @@
-name: Accessibility Tests
+name: A11y
 
 on:
   push:


### PR DESCRIPTION
The workflow name has been shortened to use the common a11y abbreviation for accessibility, making it more concise and aligned with industry conventions.