### PR TITLE
🎨 style: rename A11y workflow title

### DIFF
--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -1,4 +1,4 @@
-name: A11y
+name: A11y 
 
 on:
   push:


### PR DESCRIPTION
This commit makes a minor cosmetic change to the accessibility workflow title in the GitHub Actions configuration to ensure consistent naming convention.