### PR TITLE
🔧 chore(scripts): add typegen script for sanity schema and types

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "cypress:headless": "cypress run",
     "e2e": "start-test dev 3000 cypress:headless",
     "refresh": "pnpm i && rm -rf node_modules && rm pnpm-lock.yaml && pnpm store prune && pnpm i && pnpm format",
-    "ladle": "ladle serve"
+    "ladle": "ladle serve",
+    "typegen": "sanity schema extract && sanity typegen generate"
   },
   "dependencies": {
     "@emailjs/browser": "^4.4.1",


### PR DESCRIPTION
Adds pnpm script command to automate Sanity schema extraction and type generation, streamlining development workflow and type safety