### PR TITLE
✏️ typo: fix spelling of "komponent" in Hero test

### DIFF
--- a/src/e2e/cypress/component/Hero.cy.tsx
+++ b/src/e2e/cypress/component/Hero.cy.tsx
@@ -14,7 +14,7 @@ const content = [
   },
 ];
 
-it("Viser Hero komponentt", () => {
+it("Viser Hero komponent", () => {
   cy.mount(<Hero content={content} />);
   cy.contains("Hei!").should("be.visible");
 });


### PR DESCRIPTION
The test description had an extra "t" at the end of "komponent" which is now corrected to ensure proper Norwegian spelling in the test description.