### PR TITLE
🎨 style: add blank line after imports

### DIFF
--- a/src/components/ErrorBoundary/ErrorFallback.component.tsx
+++ b/src/components/ErrorBoundary/ErrorFallback.component.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import ReactMatrixAnimation from "../../components/Animations/Matrix.component";
 import Pill from "../../components/UI/Pill.component";
 

--- a/src/components/ErrorBoundary/Fallback.component.tsx
+++ b/src/components/ErrorBoundary/Fallback.component.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { FallbackProps } from "react-error-boundary";
+
 import ErrorFallbackWrapper from "./ErrorFallbackWrapper.component";
 
 interface FallbackComponentProps extends FallbackProps {

--- a/src/components/Kontakt/KontaktContent.component.tsx
+++ b/src/components/Kontakt/KontaktContent.component.tsx
@@ -9,7 +9,8 @@ import GenericForm from "@/components/UI/GenericForm.component";
 import { formSchema, formFields, FormData } from "./config/formConfig";
 
 /**
- * Renders contact form. Uses EmailJS to send the emails.
+ * Renders the contact form. 
+ * Uses EmailJS to send the emails.
  * @function KontaktContent
  * @returns {JSX.Element} - Rendered component
  */

--- a/src/components/Layout/Header.component.tsx
+++ b/src/components/Layout/Header.component.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import React from "react";
+
 import { MotionDiv } from "@/lib/framer/client";
+
 import MobileMenu from "./MobileMenu.component";
 import DesktopNavigation from "./DesktopNavigation.component";
 

--- a/src/components/Layout/NavigationLink.component.tsx
+++ b/src/components/Layout/NavigationLink.component.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Link from "next/link";
 import { motion } from "motion/react";
+
 import { MotionDiv } from "@/lib/framer/client";
 
 interface NavigationLinkProps {


### PR DESCRIPTION
The blank line separates import statements from local module imports, improving code organization and readability while following standard React/Next.js structure conventions.