### PR TITLE
✅ test(layout): add mobile menu close behavior test

### DIFF
--- a/src/components/Layout/MobileMenu.component.tsx
+++ b/src/components/Layout/MobileMenu.component.tsx
@@ -84,7 +84,6 @@ const MobileMenu = ({ links }: IMobileMenuProps) => {
 
   return (
     <div
-      // ref removed from here
       className="z-50 md:hidden lg:hidden xl:hidden"
       data-testid="mobilemenu"
     >

--- a/src/e2e/cypress/e2e/layout.cy.ts
+++ b/src/e2e/cypress/e2e/layout.cy.ts
@@ -1,0 +1,28 @@
+/// <reference types="cypress"/>
+
+describe("Layout", () => {
+  beforeEach(() => {
+    cy.viewport('iphone-x'); // Set mobile viewport
+    cy.visit("http://localhost:3000");
+  });
+
+  describe("Mobile Menu", () => {
+    it("should close when clicking outside the nav element", () => {
+      // Open the mobile menu
+      cy.get('[data-testid="mobilemenu"]').click();
+      
+      // Verify menu is visible
+      cy.get('[data-testid="mobile-menu"]').should('be.visible');
+      
+      // Click on the menu background (outside nav but inside motion.div)
+      // This should fail with ref on motion.div, but pass when ref is on nav
+      cy.get('[data-testid="mobile-menu"]').click('topRight', { force: true });
+      
+      // Menu should NOT be visible (passing test)
+      // because clicking outside the nav should close the menu
+      cy.get('[data-testid="mobile-menu"]').should('not.be.visible');
+    });
+  });
+});
+
+export {};


### PR DESCRIPTION
Implement e2e test to verify mobile menu closes when clicking outside nav element, ensuring proper user interaction and component behavior