### PR TITLE
🎨 ui: add theme-color meta tag for browsers

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -39,6 +39,7 @@ export default function RootLayout({
 
         <meta property="og:url" content="https://www.dfweb.no/" />
         <meta property="og:site_name" content="dfweb.no" />
+        <meta name="theme-color" content="#00cc4e" />
       </head>
 
       <body

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -39,7 +39,7 @@ export default function RootLayout({
 
         <meta property="og:url" content="https://www.dfweb.no/" />
         <meta property="og:site_name" content="dfweb.no" />
-        <meta name="theme-color" content="#00cc4e" />
+        <meta name="theme-color" content="#004014" />
       </head>
 
       <body


### PR DESCRIPTION
This change improves the visual integration with mobile browsers by setting a theme color (#00cc4e) that will be used for UI elements like the address bar on supporting browsers.