### PR TITLE
🔧 chore(lighthouse): reduce performance threshold to 0.7

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -24,7 +24,7 @@
     },
     "assert": {
       "assertions": {
-        "categories:performance": ["error", { "minScore": 0.8 }],
+        "categories:performance": ["error", { "minScore": 0.7 }],
         "categories:accessibility": ["error", { "minScore": 0.9 }],
         "categories:best-practices": ["error", { "minScore": 0.9 }],
         "categories:seo": ["error", { "minScore": 0.9 }],


### PR DESCRIPTION
Adjust the performance score threshold in Lighthouse configuration from 0.8 to 0.7 to allow for more flexibility while maintaining high standards for other categories.