### PR TITLE
🐛 fix: add optional chaining for pageContent properties

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ const DynamicIndexContent = dynamic(
   () => import("@/components/Index/IndexContent.component"),
   {
     loading: () => <div>Loading content...</div>,
-  },
+  }
 );
 
 export default async function HomePage() {
@@ -21,9 +21,9 @@ export default async function HomePage() {
     <RootLayout>
       <main>
         <div className="mt-[4.5rem] md:mt-32 overflow-hidden">
-          {pageContent.hero && <DynamicHero content={pageContent.hero} />}
+          {pageContent?.hero && <DynamicHero content={pageContent.hero} />}
         </div>
-        {pageContent.content && (
+        {pageContent?.content && (
           <DynamicIndexContent pageContent={pageContent.content} />
         )}
       </main>

--- a/src/app/prosjekter/actions.ts
+++ b/src/app/prosjekter/actions.ts
@@ -1,11 +1,10 @@
 import { client } from "@/lib/sanity/client";
 import { projectsQuery } from "@/lib/sanity/queries";
 
-import type { Project } from "@/types/sanity.types"; // Import Project type
+import type { Project } from "@/types/sanity.types";
 import { isSanityApiError } from "@/types/sanity-errors";
 
 async function fetchProjectsFromSanity(): Promise<Project[]> {
-  // Update return type
   return client.fetch(
     projectsQuery,
     {},
@@ -39,7 +38,6 @@ function handleError(error: unknown): never {
 }
 
 export async function getProjects(): Promise<Project[]> {
-  // Update return type
   try {
     return await fetchProjectsFromSanity();
   } catch (error) {

--- a/src/app/prosjekter/actions.ts
+++ b/src/app/prosjekter/actions.ts
@@ -1,10 +1,11 @@
 import { client } from "@/lib/sanity/client";
 import { projectsQuery } from "@/lib/sanity/queries";
 
-import type { ProjectsQueryResult } from "@/types/sanity.types";
+import type { Project } from "@/types/sanity.types"; // Import Project type
 import { isSanityApiError } from "@/types/sanity-errors";
 
-async function fetchProjectsFromSanity(): Promise<ProjectsQueryResult> {
+async function fetchProjectsFromSanity(): Promise<Project[]> {
+  // Update return type
   return client.fetch(
     projectsQuery,
     {},
@@ -37,7 +38,8 @@ function handleError(error: unknown): never {
   throw new Error("Failed to fetch projects");
 }
 
-export async function getProjects(): Promise<ProjectsQueryResult> {
+export async function getProjects(): Promise<Project[]> {
+  // Update return type
   try {
     return await fetchProjectsFromSanity();
   } catch (error) {

--- a/src/app/prosjekter/actions.ts
+++ b/src/app/prosjekter/actions.ts
@@ -1,15 +1,16 @@
 import { client } from "@/lib/sanity/client";
 import { projectsQuery } from "@/lib/sanity/queries";
-import type { Project } from "@/types/sanity.types";
+
+import type { ProjectsQueryResult } from "@/types/sanity.types";
 import { isSanityApiError } from "@/types/sanity-errors";
 
-async function fetchProjectsFromSanity(): Promise<Project[]> {
+async function fetchProjectsFromSanity(): Promise<ProjectsQueryResult> {
   return client.fetch(
     projectsQuery,
     {},
     {
       next: { revalidate: 3600 },
-    },
+    }
   );
 }
 
@@ -36,7 +37,7 @@ function handleError(error: unknown): never {
   throw new Error("Failed to fetch projects");
 }
 
-export async function getProjects(): Promise<Project[]> {
+export async function getProjects(): Promise<ProjectsQueryResult> {
   try {
     return await fetchProjectsFromSanity();
   } catch (error) {


### PR DESCRIPTION
Add optional chaining operators to pageContent properties to handle cases where pageContent might be undefined or missing properties, preventing potential runtime errors.