### PR TITLE
♻️ refactor: use type imports for content interfaces

### DIFF
--- a/src/components/Index/IndexContent.component.tsx
+++ b/src/components/Index/IndexContent.component.tsx
@@ -1,36 +1,16 @@
 "use client";
 
 import Section from "./Section.component";
-
-interface IChild {
-  _key: string;
-  _type: string;
-  marks: string[];
-  text: string;
-}
-
-interface IText {
-  _key: string;
-  _type: string;
-  children: IChild[];
-  markDefs: string[];
-  style: string;
-}
-
-interface IContent {
-  id: string;
-  text: IText[];
-  title: string;
-}
+import type { Pagecontent } from "@/types/sanity.types";
 
 /**
  * IndexContent component that renders multiple content sections with alternating visual styles
  * @param {Object} props - The props for the IndexContent component
- * @param {IContent[]} props.pageContent - Array of content sections to render. Each section alternates between default and alternate variant
+ * @param {Pagecontent[]} props.pageContent - Array of content sections from Sanity to render. Each section alternates between default and alternate variant
  * @returns {JSX.Element} The rendered IndexContent component
  * @throws {Error} Throws an error if no content is available
  */
-const IndexContent = ({ pageContent }: { pageContent: IContent[] }) => {
+const IndexContent = ({ pageContent }: { pageContent: Pagecontent[] }) => {
   if (!pageContent || pageContent.length === 0) {
     throw new Error("Ingen innhold tilgjengelig");
   }

--- a/src/components/Index/Section.component.tsx
+++ b/src/components/Index/Section.component.tsx
@@ -5,42 +5,26 @@ import { useState } from "react";
 import BounceInScroll from "../Animations/BounceInScroll.component";
 import Button from "../UI/Button.component";
 import { myPortableTextComponents } from "@/utils/portableTextComponents";
+import type { Pagecontent } from "@/types/sanity.types";
 
-interface IChild {
-  _key: string;
-  _type: string;
-  marks: string[];
-  text: string;
-}
-
-interface IText {
-  _key: string;
-  _type: string;
-  children: IChild[];
-  markDefs: string[];
-  style: string;
-}
-
-interface IContent {
-  text: IText[];
-  title: string;
+interface SectionProps extends Pagecontent {
   variant?: "default" | "alternate";
 }
 
 /**
  * Section component that renders a single content section
- * @param {IContent} props - The props for the Section component
- * @param {string} props.text - The text content of the section
+ * @param {SectionProps} props - The props for the Section component
+ * @param {Pagecontent['text']} props.text - The text content from Sanity
  * @param {string} props.title - The title of the section
  * @param {"default" | "alternate"} [props.variant="default"] - Visual style variant of the section. Controls background color.
  * @returns {JSX.Element | null} The rendered Section component or null if invalid data
  */
-const Section = ({ text, title, variant = "default" }: IContent) => {
+const Section = ({ text, title, variant = "default" }: SectionProps) => {
   const [shouldError, setShouldError] = useState(false);
 
   if (!title || !text) {
     console.error(
-      `Ugyldig seksjon data: tittel=${title}, tekst=${JSON.stringify(text)}`,
+      `Ugyldig seksjon data: tittel=${title}, tekst=${JSON.stringify(text)}`
     );
     return null;
   }


### PR DESCRIPTION
Replace custom interface definitions with imported types from sanity.types in IndexContent and Section components. This improves type consistency and reduces duplicate code while maintaining the same functionality.