### PR TITLE
🚚 move: extract TabOrientation type from inline to separate type

### DIFF
--- a/src/components/UI/Tabs.component.tsx
+++ b/src/components/UI/Tabs.component.tsx
@@ -3,6 +3,8 @@
 import React, { useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
 
+type TabOrientation = "horizontal" | "vertical";
+
 interface Tab {
   id: string;
   label: string;
@@ -11,7 +13,7 @@ interface Tab {
 
 interface TabsProps {
   tabs: Tab[];
-  orientation?: "horizontal" | "vertical";
+  orientation?: TabOrientation;
 }
 
 interface TabButtonProps {


### PR DESCRIPTION
This change extracts the tab orientation options from an inline union type to a named type definition for better code organization and reusability. The named type is then used in the TabsProps interface.