### PR TITLE
🔒 security: comment out Content-Security-Policy header

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -46,10 +46,12 @@ const nextConfig: NextConfig = {
             value: "ALLOW-FROM https://presentasjon.dfweb.no",
           },
           { key: "X-Content-Type-Options", value: "nosniff" },
+          /*
           {
             key: "Content-Security-Policy",
             value: buildCspHeader(cspDirectives),
           },
+          */
         ],
       },
     ];


### PR DESCRIPTION
This change temporarily disables the CSP header in the Next.js config while maintaining other security headers. Will re-enable after resolving compatibility issues with external resources.