### PR TITLE
🔒 security: uncomment Content-Security-Policy header

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -46,12 +46,11 @@ const nextConfig: NextConfig = {
             value: "ALLOW-FROM https://presentasjon.dfweb.no",
           },
           { key: "X-Content-Type-Options", value: "nosniff" },
-          /*
+
           {
             key: "Content-Security-Policy",
             value: buildCspHeader(cspDirectives),
           },
-          */
         ],
       },
     ];


### PR DESCRIPTION
This re-enables the CSP header that was previously commented out in the Next.js configuration. The CSP directives are built dynamically using the buildCspHeader function and cspDirectives object.