### PR TITLE
🚚 move[sanity]: move urlFor helper function to helpers file

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@emailjs/browser": "^4.4.1",
     "@hookform/resolvers": "^5.0.1",
     "@portabletext/react": "^3.2.1",
-    "@sanity/client": "^7.1.0",
+    "@sanity/client": "^7.2.1",
     "@sanity/image-url": "^1.1.0",
     "@vercel/speed-insights": "^1.2.0",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^3.2.1
         version: 3.2.1(react@19.1.0)
       '@sanity/client':
-        specifier: ^7.1.0
-        version: 7.1.0(debug@4.4.0)
+        specifier: ^7.2.1
+        version: 7.2.1(debug@4.4.0)
       '@sanity/image-url':
         specifier: ^1.1.0
         version: 1.1.0
@@ -49,7 +49,7 @@ importers:
         version: 15.3.2(@babel/core@7.26.10)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next-sanity:
         specifier: ^9.11.0
-        version: 9.11.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.1.0)(@sanity/icons@3.7.0(react@19.1.0))(@sanity/types@3.88.2(@types/react@19.1.4))(@sanity/ui@2.15.17(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0)))(next@15.3.2(@babel/core@7.26.10)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(sanity@3.88.2(@emotion/is-prop-valid@1.2.2)(@types/node@22.15.18)(@types/react@19.1.4)(immer@10.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(styled-components@6.1.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)(yaml@2.7.1))(styled-components@6.1.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)
+        version: 9.11.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.2.1)(@sanity/icons@3.7.0(react@19.1.0))(@sanity/types@3.88.2(@types/react@19.1.4))(@sanity/ui@2.15.17(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0)))(next@15.3.2(@babel/core@7.26.10)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(sanity@3.88.2(@emotion/is-prop-valid@1.2.2)(@types/node@22.15.18)(@types/react@19.1.4)(immer@10.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(styled-components@6.1.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)(yaml@2.7.1))(styled-components@6.1.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)
       path-to-regexp:
         specifier: ^8.2.0
         version: 8.2.0
@@ -2073,8 +2073,8 @@ packages:
     resolution: {integrity: sha512-BQRCMeDlBxwnMbFtB61HUxFf9aSb4HNVrpfrC7IFVqFf4cwcc3o5H8/nlrL9U3cDFedbe4W0AXt1mQzwbY/ljw==}
     engines: {node: '>=14.18'}
 
-  '@sanity/client@7.1.0':
-    resolution: {integrity: sha512-AQ9NV2iXSGKlWFywxT1bnLKUfyq6GnZvY0KJLZiob/12faOoWHXYOF/m1qevpahXaw0le2ytUfCbvwZMYZfH4g==}
+  '@sanity/client@7.2.1':
+    resolution: {integrity: sha512-BJ3RddlStGc+PjwBwhJIvWgXJbt3+TdWm/ywWWCNruqS5aqOSvvLUFjaAXp5ci4Wy8BL/RnZ60WIeqPi67+5xw==}
     engines: {node: '>=20'}
 
   '@sanity/codegen@3.88.2':
@@ -10837,7 +10837,7 @@ snapshots:
   '@sanity/cli@3.88.2(@types/node@22.15.18)(@types/react@19.1.4)(jiti@2.4.2)(lightningcss@1.29.2)(react@19.1.0)(typescript@5.8.3)(yaml@2.7.1)':
     dependencies:
       '@babel/traverse': 7.27.0
-      '@sanity/client': 7.1.0(debug@4.4.0)
+      '@sanity/client': 7.2.1(debug@4.4.0)
       '@sanity/codegen': 3.88.2
       '@sanity/runtime-cli': 6.2.2(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.29.2)(typescript@5.8.3)(yaml@2.7.1)
       '@sanity/telemetry': 0.8.1(react@19.1.0)
@@ -10879,10 +10879,11 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@sanity/client@7.1.0(debug@4.4.0)':
+  '@sanity/client@7.2.1(debug@4.4.0)':
     dependencies:
       '@sanity/eventsource': 5.0.2
       get-it: 8.6.7(debug@4.4.0)
+      nanoid: 3.3.11
       rxjs: 7.8.2
     transitivePeerDependencies:
       - debug
@@ -11029,7 +11030,7 @@ snapshots:
 
   '@sanity/migrate@3.88.2(@types/react@19.1.4)':
     dependencies:
-      '@sanity/client': 7.1.0(debug@4.4.0)
+      '@sanity/client': 7.2.1(debug@4.4.0)
       '@sanity/mutate': 0.12.4(debug@4.4.0)
       '@sanity/types': 3.88.2(@types/react@19.1.4)(debug@4.4.0)
       '@sanity/util': 3.88.2(@types/react@19.1.4)(debug@4.4.0)
@@ -11082,9 +11083,9 @@ snapshots:
 
   '@sanity/next-loader@1.5.2(@sanity/types@3.88.2(@types/react@19.1.4))(next@15.3.2(@babel/core@7.26.10)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@sanity/client': 7.1.0(debug@4.4.0)
+      '@sanity/client': 7.2.1(debug@4.4.0)
       '@sanity/comlink': 3.0.2
-      '@sanity/presentation-comlink': 1.0.18(@sanity/client@7.1.0)(@sanity/types@3.88.2(@types/react@19.1.4))
+      '@sanity/presentation-comlink': 1.0.18(@sanity/client@7.2.1)(@sanity/types@3.88.2(@types/react@19.1.4))
       dequal: 2.0.3
       next: 15.3.2(@babel/core@7.26.10)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
@@ -11093,27 +11094,27 @@ snapshots:
       - '@sanity/types'
       - debug
 
-  '@sanity/presentation-comlink@1.0.18(@sanity/client@7.1.0)(@sanity/types@3.88.2(@types/react@19.1.4))':
+  '@sanity/presentation-comlink@1.0.18(@sanity/client@7.2.1)(@sanity/types@3.88.2(@types/react@19.1.4))':
     dependencies:
-      '@sanity/client': 7.1.0(debug@4.4.0)
+      '@sanity/client': 7.2.1(debug@4.4.0)
       '@sanity/comlink': 3.0.2
-      '@sanity/visual-editing-types': 1.0.17(@sanity/client@7.1.0)(@sanity/types@3.88.2(@types/react@19.1.4))
+      '@sanity/visual-editing-types': 1.0.17(@sanity/client@7.2.1)(@sanity/types@3.88.2(@types/react@19.1.4))
     transitivePeerDependencies:
       - '@sanity/types'
 
-  '@sanity/presentation-comlink@1.0.19(@sanity/client@7.1.0)(@sanity/types@3.88.2(@types/react@19.1.4)(debug@4.4.0))':
+  '@sanity/presentation-comlink@1.0.19(@sanity/client@7.2.1)(@sanity/types@3.88.2(@types/react@19.1.4)(debug@4.4.0))':
     dependencies:
-      '@sanity/client': 7.1.0(debug@4.4.0)
+      '@sanity/client': 7.2.1(debug@4.4.0)
       '@sanity/comlink': 3.0.3
-      '@sanity/visual-editing-types': 1.0.18(@sanity/client@7.1.0)(@sanity/types@3.88.2(@types/react@19.1.4)(debug@4.4.0))
+      '@sanity/visual-editing-types': 1.0.18(@sanity/client@7.2.1)(@sanity/types@3.88.2(@types/react@19.1.4)(debug@4.4.0))
     transitivePeerDependencies:
       - '@sanity/types'
 
   '@sanity/preview-kit@6.1.0(@sanity/types@3.88.2(@types/react@19.1.4))(react@19.1.0)':
     dependencies:
-      '@sanity/client': 7.1.0(debug@4.4.0)
+      '@sanity/client': 7.2.1(debug@4.4.0)
       '@sanity/comlink': 3.0.2
-      '@sanity/presentation-comlink': 1.0.18(@sanity/client@7.1.0)(@sanity/types@3.88.2(@types/react@19.1.4))
+      '@sanity/presentation-comlink': 1.0.18(@sanity/client@7.2.1)(@sanity/types@3.88.2(@types/react@19.1.4))
       use-sync-external-store: 1.5.0(react@19.1.0)
     optionalDependencies:
       react: 19.1.0
@@ -11121,14 +11122,14 @@ snapshots:
       - '@sanity/types'
       - debug
 
-  '@sanity/preview-url-secret@2.1.10(@sanity/client@7.1.0)':
+  '@sanity/preview-url-secret@2.1.10(@sanity/client@7.2.1)':
     dependencies:
-      '@sanity/client': 7.1.0(debug@4.4.0)
+      '@sanity/client': 7.2.1(debug@4.4.0)
       '@sanity/uuid': 3.0.2
 
-  '@sanity/preview-url-secret@2.1.11(@sanity/client@7.1.0)':
+  '@sanity/preview-url-secret@2.1.11(@sanity/client@7.2.1)':
     dependencies:
-      '@sanity/client': 7.1.0(debug@4.4.0)
+      '@sanity/client': 7.2.1(debug@4.4.0)
       '@sanity/uuid': 3.0.2
 
   '@sanity/runtime-cli@6.2.2(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.29.2)(typescript@5.8.3)(yaml@2.7.1)':
@@ -11218,7 +11219,7 @@ snapshots:
 
   '@sanity/types@3.88.2(@types/react@19.1.4)(debug@4.4.0)':
     dependencies:
-      '@sanity/client': 7.1.0(debug@4.4.0)
+      '@sanity/client': 7.2.1(debug@4.4.0)
       '@types/react': 19.1.4
     transitivePeerDependencies:
       - debug
@@ -11272,7 +11273,7 @@ snapshots:
 
   '@sanity/util@3.88.2(@types/react@19.1.4)(debug@4.4.0)':
     dependencies:
-      '@sanity/client': 7.1.0(debug@4.4.0)
+      '@sanity/client': 7.2.1(debug@4.4.0)
       '@sanity/types': 3.88.2(@types/react@19.1.4)(debug@4.4.0)
       get-random-values-esm: 1.0.2
       moment: 2.30.1
@@ -11286,37 +11287,37 @@ snapshots:
       '@types/uuid': 8.3.4
       uuid: 8.3.2
 
-  '@sanity/visual-editing-csm@2.0.16(@sanity/client@7.1.0)(@sanity/types@3.88.2(@types/react@19.1.4))(typescript@5.8.3)':
+  '@sanity/visual-editing-csm@2.0.16(@sanity/client@7.2.1)(@sanity/types@3.88.2(@types/react@19.1.4))(typescript@5.8.3)':
     dependencies:
-      '@sanity/client': 7.1.0(debug@4.4.0)
-      '@sanity/visual-editing-types': 1.0.17(@sanity/client@7.1.0)(@sanity/types@3.88.2(@types/react@19.1.4))
+      '@sanity/client': 7.2.1(debug@4.4.0)
+      '@sanity/visual-editing-types': 1.0.17(@sanity/client@7.2.1)(@sanity/types@3.88.2(@types/react@19.1.4))
       valibot: 1.0.0(typescript@5.8.3)
     transitivePeerDependencies:
       - '@sanity/types'
       - typescript
 
-  '@sanity/visual-editing-types@1.0.17(@sanity/client@7.1.0)(@sanity/types@3.88.2(@types/react@19.1.4))':
+  '@sanity/visual-editing-types@1.0.17(@sanity/client@7.2.1)(@sanity/types@3.88.2(@types/react@19.1.4))':
     dependencies:
-      '@sanity/client': 7.1.0(debug@4.4.0)
+      '@sanity/client': 7.2.1(debug@4.4.0)
     optionalDependencies:
       '@sanity/types': 3.88.2(@types/react@19.1.4)(debug@4.4.0)
 
-  '@sanity/visual-editing-types@1.0.18(@sanity/client@7.1.0)(@sanity/types@3.88.2(@types/react@19.1.4)(debug@4.4.0))':
+  '@sanity/visual-editing-types@1.0.18(@sanity/client@7.2.1)(@sanity/types@3.88.2(@types/react@19.1.4)(debug@4.4.0))':
     dependencies:
-      '@sanity/client': 7.1.0(debug@4.4.0)
+      '@sanity/client': 7.2.1(debug@4.4.0)
     optionalDependencies:
       '@sanity/types': 3.88.2(@types/react@19.1.4)(debug@4.4.0)
 
-  '@sanity/visual-editing@2.13.20(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.1.0)(@sanity/types@3.88.2(@types/react@19.1.4))(next@15.3.2(@babel/core@7.26.10)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)':
+  '@sanity/visual-editing@2.13.20(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.2.1)(@sanity/types@3.88.2(@types/react@19.1.4))(next@15.3.2(@babel/core@7.26.10)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)':
     dependencies:
       '@sanity/comlink': 3.0.2
       '@sanity/icons': 3.7.0(react@19.1.0)
       '@sanity/insert-menu': 1.1.11(@emotion/is-prop-valid@1.2.2)(@sanity/types@3.88.2(@types/react@19.1.4)(debug@4.4.0))(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       '@sanity/mutate': 0.11.0-canary.4(xstate@5.19.2)
-      '@sanity/presentation-comlink': 1.0.18(@sanity/client@7.1.0)(@sanity/types@3.88.2(@types/react@19.1.4))
-      '@sanity/preview-url-secret': 2.1.10(@sanity/client@7.1.0)
+      '@sanity/presentation-comlink': 1.0.18(@sanity/client@7.2.1)(@sanity/types@3.88.2(@types/react@19.1.4))
+      '@sanity/preview-url-secret': 2.1.10(@sanity/client@7.2.1)
       '@sanity/ui': 2.15.16(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
-      '@sanity/visual-editing-csm': 2.0.16(@sanity/client@7.1.0)(@sanity/types@3.88.2(@types/react@19.1.4))(typescript@5.8.3)
+      '@sanity/visual-editing-csm': 2.0.16(@sanity/client@7.2.1)(@sanity/types@3.88.2(@types/react@19.1.4))(typescript@5.8.3)
       '@vercel/stega': 0.1.2
       get-random-values-esm: 1.0.2
       react: 19.1.0
@@ -11329,7 +11330,7 @@ snapshots:
       use-effect-event: 1.0.2(react@19.1.0)
       xstate: 5.19.2
     optionalDependencies:
-      '@sanity/client': 7.1.0(debug@4.4.0)
+      '@sanity/client': 7.2.1(debug@4.4.0)
       next: 15.3.2(@babel/core@7.26.10)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
@@ -16450,17 +16451,17 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  next-sanity@9.11.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.1.0)(@sanity/icons@3.7.0(react@19.1.0))(@sanity/types@3.88.2(@types/react@19.1.4))(@sanity/ui@2.15.17(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0)))(next@15.3.2(@babel/core@7.26.10)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(sanity@3.88.2(@emotion/is-prop-valid@1.2.2)(@types/node@22.15.18)(@types/react@19.1.4)(immer@10.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(styled-components@6.1.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)(yaml@2.7.1))(styled-components@6.1.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3):
+  next-sanity@9.11.0(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.2.1)(@sanity/icons@3.7.0(react@19.1.0))(@sanity/types@3.88.2(@types/react@19.1.4))(@sanity/ui@2.15.17(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0)))(next@15.3.2(@babel/core@7.26.10)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(sanity@3.88.2(@emotion/is-prop-valid@1.2.2)(@types/node@22.15.18)(@types/react@19.1.4)(immer@10.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(styled-components@6.1.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)(yaml@2.7.1))(styled-components@6.1.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3):
     dependencies:
       '@portabletext/react': 3.2.1(react@19.1.0)
-      '@sanity/client': 7.1.0(debug@4.4.0)
+      '@sanity/client': 7.2.1(debug@4.4.0)
       '@sanity/icons': 3.7.0(react@19.1.0)
       '@sanity/next-loader': 1.5.2(@sanity/types@3.88.2(@types/react@19.1.4))(next@15.3.2(@babel/core@7.26.10)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
       '@sanity/preview-kit': 6.1.0(@sanity/types@3.88.2(@types/react@19.1.4))(react@19.1.0)
-      '@sanity/preview-url-secret': 2.1.10(@sanity/client@7.1.0)
+      '@sanity/preview-url-secret': 2.1.10(@sanity/client@7.2.1)
       '@sanity/types': 3.88.2(@types/react@19.1.4)(debug@4.4.0)
       '@sanity/ui': 2.15.17(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
-      '@sanity/visual-editing': 2.13.20(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.1.0)(@sanity/types@3.88.2(@types/react@19.1.4))(next@15.3.2(@babel/core@7.26.10)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)
+      '@sanity/visual-editing': 2.13.20(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.2.1)(@sanity/types@3.88.2(@types/react@19.1.4))(next@15.3.2(@babel/core@7.26.10)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-is@18.3.1)(react@19.1.0)(styled-components@6.1.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)
       groq: 3.88.0
       history: 5.3.0
       next: 15.3.2(@babel/core@7.26.10)(@playwright/test@1.52.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -17541,7 +17542,7 @@ snapshots:
       '@sanity/asset-utils': 2.2.1
       '@sanity/bifur-client': 0.4.1
       '@sanity/cli': 3.88.2(@types/node@22.15.18)(@types/react@19.1.4)(jiti@2.4.2)(lightningcss@1.29.2)(react@19.1.0)(typescript@5.8.3)(yaml@2.7.1)
-      '@sanity/client': 7.1.0(debug@4.4.0)
+      '@sanity/client': 7.2.1(debug@4.4.0)
       '@sanity/color': 3.0.6
       '@sanity/comlink': 3.0.3
       '@sanity/diff': 3.88.2
@@ -17558,8 +17559,8 @@ snapshots:
       '@sanity/message-protocol': 0.13.1
       '@sanity/migrate': 3.88.2(@types/react@19.1.4)
       '@sanity/mutator': 3.88.2(@types/react@19.1.4)
-      '@sanity/presentation-comlink': 1.0.19(@sanity/client@7.1.0)(@sanity/types@3.88.2(@types/react@19.1.4)(debug@4.4.0))
-      '@sanity/preview-url-secret': 2.1.11(@sanity/client@7.1.0)
+      '@sanity/presentation-comlink': 1.0.19(@sanity/client@7.2.1)(@sanity/types@3.88.2(@types/react@19.1.4)(debug@4.4.0))
+      '@sanity/preview-url-secret': 2.1.11(@sanity/client@7.2.1)
       '@sanity/schema': 3.88.2(@types/react@19.1.4)(debug@4.4.0)
       '@sanity/sdk': 0.0.0-alpha.25(@types/react@19.1.4)(debug@4.4.0)(immer@10.1.1)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0))
       '@sanity/telemetry': 0.8.1(react@19.1.0)

--- a/src/components/Prosjekter/ProsjektCard.component.tsx
+++ b/src/components/Prosjekter/ProsjektCard.component.tsx
@@ -4,9 +4,8 @@ import React from "react";
 import Button from "@/components/UI/Button.component";
 import BounceInScroll from "@/components/Animations/BounceInScroll.component";
 
-import { urlFor } from "@/lib/sanity/client";
-
 import type { Project } from "@/types/sanity.types";
+import { urlFor } from "@/lib/sanity/helpers";
 
 /**
  * Renders a card displaying information about a single project.

--- a/src/lib/sanity/client.ts
+++ b/src/lib/sanity/client.ts
@@ -1,4 +1,5 @@
-import { createClient } from "next-sanity";
+//import { createClient } from "next-sanity";
+import { createClient } from "@sanity/client";
 
 const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || "41s7iutf";
 const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET || "production";

--- a/src/lib/sanity/client.ts
+++ b/src/lib/sanity/client.ts
@@ -1,6 +1,4 @@
-import imageUrlBuilder from "@sanity/image-url";
 import { createClient } from "next-sanity";
-import type { Project } from "@/types/sanity.types";
 
 const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || "41s7iutf";
 const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET || "production";
@@ -12,9 +10,3 @@ export const client = createClient({
   apiVersion,
   useCdn: true,
 });
-
-const builder = imageUrlBuilder(client);
-
-export function urlFor(source: NonNullable<Project["projectimage"]>) {
-  return builder.image(source);
-}

--- a/src/lib/sanity/helpers.ts
+++ b/src/lib/sanity/helpers.ts
@@ -1,8 +1,10 @@
 import { client } from "./client";
 import imageUrlBuilder from "@sanity/image-url";
 
+import type { Project } from "@/types/sanity.types";
+
 const builder = imageUrlBuilder(client);
 
-export const urlFor = (source: string) => {
+export const urlFor = (source: NonNullable<Project["projectimage"]>) => {
   return builder.image(source);
 };

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -24,6 +24,7 @@ export const projectsQuery = groq`
   }
 `;
 
+/*
 export const cvQuery = groq`
   *[_type == "cv"][0] {
     keyQualifications,
@@ -47,6 +48,7 @@ export const cvQuery = groq`
     }
   }
 `;
+*/
 
 export const pageContentQuery = groq`
   *[_type == 'page' && title match 'Hjem'][0]{


### PR DESCRIPTION
The urlFor function for generating Sanity image URLs has been relocated from the client.ts file to the helpers.ts file where it conceptually belongs. This improves code organization and separation of concerns.