### PR TITLE
🔥 cleanup: remove groq import and template literals

### DIFF
--- a/src/__mocks__/sanity-client.ts
+++ b/src/__mocks__/sanity-client.ts
@@ -4,17 +4,15 @@ export const client = {
 };
 
 export function urlFor() {
-  return {
-    width: () => ({
-      height: () => ({
-        fit: () => ({
-          quality: () => ({
-            auto: () => ({
-              url: () => "/mocked-image-url",
-            }),
-          }),
-        }),
-      }),
-    }),
+  // Create a chainable API with methods that return the same object
+  const imageUrlBuilder = {
+    width: () => imageUrlBuilder,
+    height: () => imageUrlBuilder,
+    fit: () => imageUrlBuilder,
+    quality: () => imageUrlBuilder,
+    auto: () => imageUrlBuilder,
+    url: () => "/mocked-image-url",
   };
+
+  return imageUrlBuilder;
 }

--- a/src/__mocks__/sanity-client.ts
+++ b/src/__mocks__/sanity-client.ts
@@ -1,0 +1,20 @@
+// Mock implementation of the Sanity client
+export const client = {
+  fetch: jest.fn().mockResolvedValue([]),
+};
+
+export function urlFor() {
+  return {
+    width: () => ({
+      height: () => ({
+        fit: () => ({
+          quality: () => ({
+            auto: () => ({
+              url: () => "/mocked-image-url",
+            }),
+          }),
+        }),
+      }),
+    }),
+  };
+}

--- a/src/__mocks__/sanity-client.ts
+++ b/src/__mocks__/sanity-client.ts
@@ -1,10 +1,8 @@
-// Mock implementation of the Sanity client
 export const client = {
   fetch: jest.fn().mockResolvedValue([]),
 };
 
 export function urlFor() {
-  // Create a chainable API with methods that return the same object
   const imageUrlBuilder = {
     width: () => imageUrlBuilder,
     height: () => imageUrlBuilder,

--- a/src/__tests__/Prosjekter/page.test.tsx
+++ b/src/__tests__/Prosjekter/page.test.tsx
@@ -5,6 +5,9 @@ import ProsjekterPage from "@/app/prosjekter/page";
 import { getProjects } from "@/app/prosjekter/actions";
 
 // Mock the components and functions
+jest.mock("@/lib/sanity/client", () => {
+  return require("../../../src/__mocks__/sanity-client");
+});
 jest.mock("@/app/prosjekter/actions");
 jest.mock("@/components/UI/PageHeader.component", () => {
   return function MockPageHeader({ children }: { children: React.ReactNode }) {

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -1,6 +1,4 @@
-import { groq } from "next-sanity";
-
-export const projectsQuery = groq`
+export const projectsQuery = `
   *[_type == "project"] | order(featureOrder asc) {
     id,
     name,
@@ -24,7 +22,7 @@ export const projectsQuery = groq`
   }
 `;
 
-export const cvQuery = groq`
+export const cvQuery = `
   *[_type == "cv"][0] {
     keyQualifications,
     experience[] {
@@ -48,7 +46,7 @@ export const cvQuery = groq`
   }
 `;
 
-export const pageContentQuery = groq`
+export const pageContentQuery = `
   *[_type == 'page' && title match 'Hjem'][0]{
     "id": _id, 
     title, 
@@ -57,7 +55,7 @@ export const pageContentQuery = groq`
   }
 `;
 
-export const navigationQuery = groq`
+export const navigationQuery = `
   *[_type == "navigation"][0] {
     title,
     links[] {
@@ -70,7 +68,7 @@ export const navigationQuery = groq`
   }
 `;
 
-export const settingsQuery = groq`
+export const settingsQuery = `
   *[_type == "settings"][0] {
     footerCopyrightText
   }


### PR DESCRIPTION
- Remove unused import from the sanity queries file and simplify the query structure by removing template literals. This makes the code cleaner and more straightforward while maintaining functionality.
- The commit creates a mock implementation of the Sanity client for testing purposes and updates the Prosjekter page test to use this mock. This allows tests to run without real Sanity API calls.