### PR TITLE
♻️ refactor: create reusable GenericCVSectionContent component

### DIFF
--- a/src/components/CV/EducationTabContent.tsx
+++ b/src/components/CV/EducationTabContent.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import GenericCVSectionContent from "./GenericCVSectionContent";
 
 interface Education {
   period?: string;
@@ -12,17 +13,11 @@ interface EducationTabContentProps {
 }
 
 const EducationTabContent: React.FC<EducationTabContentProps> = ({ education }) => (
-  <div className="text-slate-300/[0.9]">
-    {education?.map((edu) => (
-      <div key={edu.description ?? ""} className="mb-6">
-        <h3 className="font-semibold text-slate-100">
-          {edu.period ?? ""} - {edu.institution ?? ""}
-        </h3>
-        {edu.degree && <p className="italic">{edu.degree}</p>}
-        <p>{edu.description ?? ""}</p>
-      </div>
-    ))}
-  </div>
+  <GenericCVSectionContent<Education>
+    items={education}
+    renderHeaderContent={(edu) => <>{edu.period ?? ""} - {edu.institution ?? ""}</>}
+    renderSubHeaderContent={(edu) => edu.degree && <p className="italic">{edu.degree}</p>}
+  />
 );
 
 export default EducationTabContent;

--- a/src/components/CV/ExperienceTabContent.tsx
+++ b/src/components/CV/ExperienceTabContent.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import GenericCVSectionContent from "./GenericCVSectionContent";
 
 interface Experience {
   period?: string;
@@ -12,17 +13,11 @@ interface ExperienceTabContentProps {
 }
 
 const ExperienceTabContent: React.FC<ExperienceTabContentProps> = ({ experience }) => (
-  <div className="text-slate-300/[0.9]">
-    {experience?.map((exp) => (
-      <div key={exp.description ?? ""} className="mb-6">
-        <h3 className="font-semibold text-slate-100">
-          {exp.period ?? ""} - {exp.company ?? ""}
-        </h3>
-        {exp.role && <p className="italic">{exp.role}</p>}
-        <p>{exp.description ?? ""}</p>
-      </div>
-    ))}
-  </div>
+  <GenericCVSectionContent<Experience>
+    items={experience}
+    renderHeaderContent={(exp) => <>{exp.period ?? ""} - {exp.company ?? ""}</>}
+    renderSubHeaderContent={(exp) => exp.role && <p className="italic">{exp.role}</p>}
+  />
 );
 
 export default ExperienceTabContent;

--- a/src/components/CV/GenericCVSectionContent.tsx
+++ b/src/components/CV/GenericCVSectionContent.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+interface BaseItem {
+  description?: string;
+}
+
+interface GenericCVSectionContentProps<T extends BaseItem> {
+  items?: T[];
+  renderHeaderContent: (item: T) => React.ReactNode;
+  renderSubHeaderContent?: (item: T) => React.ReactNode;
+}
+
+const GenericCVSectionContent = <T extends BaseItem>({
+  items,
+  renderHeaderContent,
+  renderSubHeaderContent,
+}: GenericCVSectionContentProps<T>) => (
+  <div className="text-slate-300/[0.9]">
+    {items?.map((item, index) => (
+      <div key={item.description ?? `item-${index}`} className="mb-6">
+        <h3 className="font-semibold text-slate-100">
+          {renderHeaderContent(item)}
+        </h3>
+        {renderSubHeaderContent && renderSubHeaderContent(item)}
+        <p>{item.description ?? ""}</p>
+      </div>
+    ))}
+  </div>
+);
+
+export default GenericCVSectionContent;

--- a/src/components/CV/GenericCVSectionContent.tsx
+++ b/src/components/CV/GenericCVSectionContent.tsx
@@ -21,7 +21,7 @@ const GenericCVSectionContent = <T extends BaseItem>({
         <h3 className="font-semibold text-slate-100">
           {renderHeaderContent(item)}
         </h3>
-        {renderSubHeaderContent && renderSubHeaderContent(item)}
+        {renderSubHeaderContent?.(item)}
         <p>{item.description ?? ""}</p>
       </div>
     ))}

--- a/src/components/CV/VolunteerWorkTabContent.tsx
+++ b/src/components/CV/VolunteerWorkTabContent.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import GenericCVSectionContent from "./GenericCVSectionContent";
 
 interface VolunteerWork {
   period?: string;
@@ -12,17 +13,11 @@ interface VolunteerWorkTabContentProps {
 }
 
 const VolunteerWorkTabContent: React.FC<VolunteerWorkTabContentProps> = ({ volunteerWork }) => (
-  <div className="text-slate-300/[0.9]">
-    {volunteerWork?.map((vol) => (
-      <div key={vol.description ?? ""} className="mb-6">
-        <h3 className="font-semibold text-slate-100">
-          {vol.period ?? ""} - {vol.organization ?? ""}
-        </h3>
-        {vol.role && <p className="italic">{vol.role}</p>}
-        <p>{vol.description ?? ""}</p>
-      </div>
-    ))}
-  </div>
+  <GenericCVSectionContent<VolunteerWork>
+    items={volunteerWork}
+    renderHeaderContent={(vol) => <>{vol.period ?? ""} - {vol.organization ?? ""}</>}
+    renderSubHeaderContent={(vol) => vol.role && <p className="italic">{vol.role}</p>}
+  />
 );
 
 export default VolunteerWorkTabContent;


### PR DESCRIPTION
This refactors the CV section components to use a shared generic component for rendering education, experience, and volunteer work sections. The new component reduces code duplication while maintaining the same UI appearance.