### PR TITLE
🔥 cleanup: replace references to any in code

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -21,8 +21,8 @@ declare global {
       toHaveLength(length: number): R;
 
       // Jest matchers
-      toBe(expected: any): R;
-      toEqual(expected: any): R;
+      toBe(expected: unknown): R;
+      toEqual(expected: unknown): R;
       toBeNull(): R;
       toBeDefined(): R;
       toBeUndefined(): R;
@@ -32,10 +32,10 @@ declare global {
       toBeLessThan(number: number): R;
       toBeLessThanOrEqual(number: number): R;
       toBeGreaterThanOrEqual(number: number): R;
-      toContain(item: any): R;
+      toContain(item: unknown): R;
       toHaveBeenCalled(): R;
       toHaveBeenCalledTimes(number: number): R;
-      toHaveBeenCalledWith(...args: any[]): R;
+      toHaveBeenCalledWith(...args: unknown[]): R;
       toHaveBeenCalledExactly(times: number): R;
       toThrow(error?: string | Error | RegExp): R;
       toMatch(regexpOrString: string | RegExp): R;
@@ -46,15 +46,18 @@ declare global {
   }
 }
 
+type ExpectWithGetState = typeof expect & {
+  getState: () => { testPath?: string };
+};
+
 function getTestPath(): string | undefined {
-  return (expect as any).getState().testPath;
+  const expectWithGetState = expect as ExpectWithGetState;
+  return expectWithGetState.getState().testPath;
 }
 
 beforeEach(async () => {
   const testPath = getTestPath();
 
-  // Skip this check for test-rule.test.tsx since it contains intentionally invalid tests
-  // Also skip if we can't determine the test path
   if (
     testPath &&
     !testPath.includes("test-rule.test.tsx") &&
@@ -70,7 +73,7 @@ beforeEach(async () => {
             "Each test should include:\n" +
             "// Arrange - Set up test data and conditions\n" +
             "// Act - Perform the action being tested\n" +
-            "// Assert - Verify the results",
+            "// Assert - Verify the results"
         );
       }
     } catch (error) {

--- a/src/__tests__/Animations/Matrix.test.tsx
+++ b/src/__tests__/Animations/Matrix.test.tsx
@@ -27,10 +27,7 @@ const mockBitmapContext = {
 } as unknown as ImageBitmapRenderingContext;
 
 // Use a single mock implementation that handles different context types
-HTMLCanvasElement.prototype.getContext = function (
-  contextId: string,
-  options?: any,
-) {
+HTMLCanvasElement.prototype.getContext = function (contextId: string) {
   switch (contextId) {
     case "2d":
       return mock2DContext;

--- a/src/__tests__/Animations/Matrix.test.tsx
+++ b/src/__tests__/Animations/Matrix.test.tsx
@@ -39,7 +39,7 @@ HTMLCanvasElement.prototype.getContext = function (contextId: string) {
     default:
       return null;
   }
-} as any;
+} as typeof HTMLCanvasElement.prototype.getContext;
 
 global.requestAnimationFrame = jest.fn((cb) => setTimeout(cb, 0));
 

--- a/src/__tests__/Animations/Matrix.test.tsx
+++ b/src/__tests__/Animations/Matrix.test.tsx
@@ -26,7 +26,6 @@ const mockBitmapContext = {
   transferFromImageBitmap: jest.fn(),
 } as unknown as ImageBitmapRenderingContext;
 
-// Use a single mock implementation that handles different context types
 HTMLCanvasElement.prototype.getContext = function (contextId: string) {
   switch (contextId) {
     case "2d":


### PR DESCRIPTION
- TypeScript's `unknown` type provides better type safety than `any` as it requires type checking before use. This change improves code quality by enforcing stricter type checks in Jest matchers and test utilities.
- Replace `as any` with a more specific type assertion using the correct typeof the prototype method, enhancing type safety and code clarity without changing functionality.