### PR TITLE
✨ feat[Section]: add optional showDebugButton prop

### DIFF
--- a/src/__tests__/Index/Section.test.tsx
+++ b/src/__tests__/Index/Section.test.tsx
@@ -17,7 +17,8 @@ jest.mock("@portabletext/react", () => ({
 }));
 
 describe("Section Component", () => {
-  const mockProps = {
+  const mockProps: import("@/types/sanity.types").Pagecontent = {
+    _type: "pagecontent",
     title: "Test Title",
     text: [
       {
@@ -66,7 +67,9 @@ describe("Section Component", () => {
       .mockImplementation(() => {});
 
     // Act - Perform the action being tested
-    const { container } = render(<Section title="" text={[]} />);
+    const { container } = render(
+      <Section _type="pagecontent" title="" text={[]} />
+    );
 
     // Assert - Verify the results
     expect(container.firstChild).toBeNull();
@@ -85,7 +88,7 @@ describe("Section Component", () => {
     // Assert - Verify the results
     expect(errorButton).toBeInTheDocument();
     expect(() => fireEvent.click(errorButton)).toThrow(
-      "En uventet feil har oppstått",
+      "En uventet feil har oppstått"
     );
   });
 
@@ -98,5 +101,17 @@ describe("Section Component", () => {
 
     // Assert - Verify the results
     expect(screen.queryByText("Utløs Testfeil")).not.toBeInTheDocument();
+  });
+
+  it("does not show error button when showDebugButton is false in development mode", () => {
+    process.env = { ...originalEnv, NODE_ENV: "development" };
+    render(<Section {...mockProps} showDebugButton={false} />);
+    expect(screen.queryByText("Utløs Testfeil")).not.toBeInTheDocument();
+  });
+
+  it("shows error button when showDebugButton is true in development mode", () => {
+    process.env = { ...originalEnv, NODE_ENV: "development" };
+    render(<Section {...mockProps} showDebugButton={true} />);
+    expect(screen.getByText("Utløs Testfeil")).toBeInTheDocument();
   });
 });

--- a/src/components/Index/Section.component.tsx
+++ b/src/components/Index/Section.component.tsx
@@ -9,6 +9,7 @@ import type { Pagecontent } from "@/types/sanity.types";
 
 interface SectionProps extends Pagecontent {
   variant?: "default" | "alternate";
+  showDebugButton?: boolean;
 }
 
 /**
@@ -19,7 +20,7 @@ interface SectionProps extends Pagecontent {
  * @param {"default" | "alternate"} [props.variant="default"] - Visual style variant of the section. Controls background color.
  * @returns {JSX.Element | null} The rendered Section component or null if invalid data
  */
-const Section = ({ text, title, variant = "default" }: SectionProps) => {
+const Section = ({ text, title, variant = "default", showDebugButton = true }: SectionProps) => {
   const [shouldError, setShouldError] = useState(false);
 
   if (!title || !text) {
@@ -67,7 +68,7 @@ const Section = ({ text, title, variant = "default" }: SectionProps) => {
               />
             </div>
           </div>
-          {process.env.NODE_ENV === "development" && (
+          {process.env.NODE_ENV === "development" && showDebugButton && (
             <Button onClick={() => setShouldError(true)} type="button">
               Utløs Testfeil
             </Button>

--- a/src/components/Index/Section.component.tsx
+++ b/src/components/Index/Section.component.tsx
@@ -18,6 +18,7 @@ interface SectionProps extends Pagecontent {
  * @param {Pagecontent['text']} props.text - The text content from Sanity
  * @param {string} props.title - The title of the section
  * @param {"default" | "alternate"} [props.variant="default"] - Visual style variant of the section. Controls background color.
+ * @param {boolean} [props.showDebugButton=true] - If true (default), shows the debug button in development mode. Set to false to hide the button (e.g., in stories or production).
  * @returns {JSX.Element | null} The rendered Section component or null if invalid data
  */
 const Section = ({ text, title, variant = "default", showDebugButton = true }: SectionProps) => {

--- a/src/stories/components/Index/Section.stories.tsx
+++ b/src/stories/components/Index/Section.stories.tsx
@@ -62,3 +62,23 @@ export const NarrowContainer = () => (
     />
   </div>
 );
+
+// Section with debug button hidden
+export const DebugButtonHidden = () => (
+  <Section
+    _type="pagecontent"
+    title="No Debug Button"
+    text={mockPortableText}
+    showDebugButton={false}
+  />
+);
+
+// Section with debug button explicitly shown (default behavior)
+export const DebugButtonVisible = () => (
+  <Section
+    _type="pagecontent"
+    title="Debug Button Visible"
+    text={mockPortableText}
+    showDebugButton={true}
+  />
+);


### PR DESCRIPTION
- Added ability to conditionally show or hide the debug button in Section component while preserving existing behavior. The new prop defaults to true for backward compatibility.