### PR TITLE
✅ test[cv]: add tests for EducationTabContent and ExperienceTabContent

### DIFF
--- a/src/__tests__/CV/EducationTabContent.test.tsx
+++ b/src/__tests__/CV/EducationTabContent.test.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import EducationTabContent from "@/components/CV/EducationTabContent";
+
+describe("EducationTabContent", () => {
+  it("renders education items with degree (conditional branch)", () => {
+    // Arrange
+    const mockEducation = [
+      {
+        period: "2020-2024",
+        institution: "University of Technology",
+        degree: "Bachelor of Computer Science",
+        description: "Studied computer science fundamentals",
+      },
+    ];
+
+    // Act
+    render(<EducationTabContent education={mockEducation} />);
+
+    // Assert
+    expect(screen.getByText("2020-2024 - University of Technology")).toBeInTheDocument();
+    expect(screen.getByText("Bachelor of Computer Science")).toBeInTheDocument();
+  });
+
+  it("renders education items without degree (conditional branch)", () => {
+    // Arrange
+    const mockEducation = [
+      {
+        period: "2020-2024",
+        institution: "University of Technology",
+        description: "Studied computer science fundamentals",
+        // No degree property to test the conditional
+      },
+    ];
+
+    // Act
+    render(<EducationTabContent education={mockEducation} />);
+
+    // Assert
+    expect(screen.getByText("2020-2024 - University of Technology")).toBeInTheDocument();
+    expect(screen.queryByText("Bachelor of Computer Science")).not.toBeInTheDocument();
+  });
+
+  it("renders education items with empty degree (conditional branch)", () => {
+    // Arrange
+    const mockEducation = [
+      {
+        period: "2020-2024",
+        institution: "University of Technology",
+        degree: "", // Empty string to test the conditional
+        description: "Studied computer science fundamentals",
+      },
+    ];
+
+    // Act
+    render(<EducationTabContent education={mockEducation} />);
+
+    // Assert
+    expect(screen.getByText("2020-2024 - University of Technology")).toBeInTheDocument();
+    expect(screen.queryByText("Bachelor of Computer Science")).not.toBeInTheDocument();
+  });
+
+  it("renders with undefined education", () => {
+    // Act
+    render(<EducationTabContent />);
+
+    // Assert - Should not crash and render empty content
+    expect(screen.queryByText("University of Technology")).not.toBeInTheDocument();
+  });
+
+  it("renders with empty education array", () => {
+    // Act
+    render(<EducationTabContent education={[]} />);
+
+    // Assert - Should not crash and render empty content
+    expect(screen.queryByText("University of Technology")).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/CV/ExperienceTabContent.test.tsx
+++ b/src/__tests__/CV/ExperienceTabContent.test.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import ExperienceTabContent from "@/components/CV/ExperienceTabContent";
+
+describe("ExperienceTabContent", () => {
+  it("renders experience items with role (conditional branch)", () => {
+    // Arrange
+    const mockExperience = [
+      {
+        period: "2022-2024",
+        company: "Tech Company Inc",
+        role: "Senior Developer",
+        description: "Developed web applications",
+      },
+    ];
+
+    // Act
+    render(<ExperienceTabContent experience={mockExperience} />);
+
+    // Assert
+    expect(screen.getByText("2022-2024 - Tech Company Inc")).toBeInTheDocument();
+    expect(screen.getByText("Senior Developer")).toBeInTheDocument();
+  });
+
+  it("renders experience items without role (conditional branch)", () => {
+    // Arrange
+    const mockExperience = [
+      {
+        period: "2022-2024",
+        company: "Tech Company Inc",
+        description: "Developed web applications",
+        // No role property to test the conditional
+      },
+    ];
+
+    // Act
+    render(<ExperienceTabContent experience={mockExperience} />);
+
+    // Assert
+    expect(screen.getByText("2022-2024 - Tech Company Inc")).toBeInTheDocument();
+    expect(screen.queryByText("Senior Developer")).not.toBeInTheDocument();
+  });
+
+  it("renders experience items with empty role (conditional branch)", () => {
+    // Arrange
+    const mockExperience = [
+      {
+        period: "2022-2024",
+        company: "Tech Company Inc",
+        role: "", // Empty string to test the conditional
+        description: "Developed web applications",
+      },
+    ];
+
+    // Act
+    render(<ExperienceTabContent experience={mockExperience} />);
+
+    // Assert
+    expect(screen.getByText("2022-2024 - Tech Company Inc")).toBeInTheDocument();
+    expect(screen.queryByText("Senior Developer")).not.toBeInTheDocument();
+  });
+
+  it("renders with undefined experience", () => {
+    // Act
+    render(<ExperienceTabContent />);
+
+    // Assert - Should not crash and render empty content
+    expect(screen.queryByText("Tech Company Inc")).not.toBeInTheDocument();
+  });
+
+  it("renders with empty experience array", () => {
+    // Act
+    render(<ExperienceTabContent experience={[]} />);
+
+    // Assert - Should not crash and render empty content
+    expect(screen.queryByText("Tech Company Inc")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
- Implements comprehensive test coverage for CV tab components with various conditional scenarios. Tests ensure proper rendering of education and experience sections with and without optional properties.