### PR TITLE
📦 deps: add tar-fs dependency with version >=3.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "sanity": "^3.91.0",
     "sitemap": "^8.0.0",
     "ts-node": "^10.9.2",
-    "zod": "^3.25.51"
+    "zod": "^3.25.51",
+    "tar-fs": ">=3.0.9"
   },
   "devDependencies": {
     "@jest/expect": "^29.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,9 @@ importers:
       sitemap:
         specifier: ^8.0.0
         version: 8.0.0
+      tar-fs:
+        specifier: ">=3.0.9"
+        version: 3.0.9
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.11.18(@swc/helpers@0.5.15))(@types/node@22.15.29)(typescript@5.8.3)
@@ -13357,10 +13360,10 @@ packages:
         integrity: sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==,
       }
 
-  tar-fs@3.0.8:
+  tar-fs@3.0.9:
     resolution:
       {
-        integrity: sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==,
+        integrity: sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==,
       }
 
   tar-stream@1.6.2:
@@ -16880,7 +16883,7 @@ snapshots:
       progress: 2.0.3
       proxy-agent: 6.5.0
       semver: 7.7.2
-      tar-fs: 3.0.8
+      tar-fs: 3.0.9
       unbzip2-stream: 1.4.3
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -24360,7 +24363,7 @@ snapshots:
       pump: 3.0.2
       tar-stream: 2.2.0
 
-  tar-fs@3.0.8:
+  tar-fs@3.0.9:
     dependencies:
       pump: 3.0.2
       tar-stream: 3.1.7


### PR DESCRIPTION
- This adds the tar-fs package to handle tar file operations securely with a minimum version requirement to avoid known vulnerabilities.