### PR TITLE
🔥 cleanup: remove unused cypress type definition file

### DIFF
--- a/cypress.d.ts
+++ b/cypress.d.ts
@@ -1,9 +1,0 @@
-import { mount } from "cypress/react";
-
-declare global {
-  namespace Cypress {
-    interface Chainable {
-      mount: typeof mount;
-    }
-  }
-}


### PR DESCRIPTION
This file is no longer needed