### PR TITLE
🐛 fix: downgrade actions/setup-node from v5 to v4

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -21,7 +21,7 @@ jobs:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'pnpm'


### PR DESCRIPTION
The actions/setup-node@v5 was causing compatibility issues with our CI pipeline. Downgrading to the more stable v4 version resolves these issues while maintaining all required functionality.