### PR TITLE
👷 ci: pin cypress github action to specific commit hash

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -44,7 +44,7 @@ jobs:
         run: pnpm exec cypress verify
 
       - name: Cypress run
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@b8ba51a856ba5f4c15cf39007636d4ab04f23e3c
         with:
           build: pnpm build
           start: pnpm dev


### PR DESCRIPTION
This change replaces the version tag with a specific commit hash for the cypress-io/github-action to ensure consistent CI behavior and prevent potential issues from future updates.