### PR TITLE
📦 deps: update cypress browser container image

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         browser: [chrome, firefox, edge]
     container:
-      image: cypress/browsers:node-20.17.0-chrome-128.0.6613.119-1-ff-130.0-edge-128.0.2739.63-1
+      image: cypress/browsers:node-22.18.0-chrome-139.0.7258.138-1-ff-142.0-edge-139.0.3405.102-1
       options: --user 1001
     steps:
       - name: Checkout


### PR DESCRIPTION
The cypress container image is updated to use newer browser versions with node 22.18.0, chrome 139, firefox 142, and edge 139, replacing the previously used older versions.