### PR TITLE
📝 docs: add project-specific guidance for agents

### DIFF
--- a/.roo/rules-architect/AGENTS.md
+++ b/.roo/rules-architect/AGENTS.md
@@ -1,0 +1,11 @@
+# Project Architecture Rules (Non-Obvious Only)
+
+- **Component Architecture**: Uses `.component.tsx` suffix pattern throughout (not standard React convention)
+- **Test Architecture**: Dual enforcement of AAA pattern via ESLint plugin AND runtime validation
+- **Custom ESLint Plugin**: Local plugin architecture in `src/utils/eslint/` with custom rule implementation
+- **Matrix Component**: Intentionally excluded from test coverage architecture (performance component)
+- **E2E Test Architecture**: Split between Cypress (`src/e2e/cypress/`) and Playwright (`src/e2e/playwright/`)
+- **CSP Architecture**: Custom security headers allow specific iframe embedding for `https://presentasjon.dfweb.no`
+- **Sanity Architecture**: Hardcoded fallback configuration prevents runtime failures
+- **Development Architecture**: Turbopack integration changes standard Next.js build pipeline
+- **Testing Architecture**: Runtime AAA validation in `jest.setup.ts` prevents pattern violations

--- a/.roo/rules-ask/AGENTS.md
+++ b/.roo/rules-ask/AGENTS.md
@@ -1,0 +1,11 @@
+# Project Documentation Rules (Non-Obvious Only)
+
+- **Component Naming**: `.component.tsx` suffix used instead of standard React naming convention
+- **Test Structure**: E2E tests in `src/e2e/cypress/` and `src/e2e/playwright/` (not standard `__tests__` or `test/` folders)
+- **Custom ESLint Plugin**: Local plugin at `src/utils/eslint/` - not a published package
+- **AAA Pattern**: Mandatory test comments enforced by both ESLint AND runtime validation
+- **Matrix Component**: Intentionally excluded from test coverage (see package.json script)
+- **Sanity Configuration**: Uses hardcoded fallback values (projectId: "41s7iutf", dataset: "production")
+- **CSP Configuration**: Custom headers allow `https://presentasjon.dfweb.no` for iframe embedding
+- **Development Setup**: Uses Turbopack (`--turbopack` flag) instead of standard webpack
+- **Refresh Command**: `pnpm refresh` does complete cleanup including store prune and lock file removal

--- a/.roo/rules-code/AGENTS.md
+++ b/.roo/rules-code/AGENTS.md
@@ -1,0 +1,10 @@
+# Project Coding Rules (Non-Obvious Only)
+
+- **AAA Pattern Enforcement**: Tests MUST include `// Arrange`, `// Act`, `// Assert` comments - enforced by custom ESLint plugin in `src/utils/eslint/` AND runtime validation in `jest.setup.ts`
+- **Component Naming**: Use `.component.tsx` suffix (not standard React convention)
+- **Matrix Component**: Intentionally excluded from test coverage via package.json script
+- **Custom ESLint Plugin**: Local plugin at `src/utils/eslint/` provides `test-rules/arrange-act-assert` rule
+- **Test Utils**: Use `checkAAAPattern()` from `src/utils/test-utils.ts` for AAA validation
+- **Sanity Client**: Hardcoded fallbacks in `src/lib/sanity/client.ts` (projectId: "41s7iutf", dataset: "production")
+- **CSP Headers**: Custom Content Security Policy allows `https://presentasjon.dfweb.no` for iframe embedding
+- **Turbopack Dev**: Development server uses `--turbopack` flag (non-standard Next.js setup)

--- a/.roo/rules-debug/AGENTS.md
+++ b/.roo/rules-debug/AGENTS.md
@@ -1,0 +1,9 @@
+# Project Debug Rules (Non-Obvious Only)
+
+- **AAA Pattern Validation**: Tests fail at runtime if missing `// Arrange`, `// Act`, `// Assert` comments (validated in `jest.setup.ts`)
+- **Matrix Component Debug**: Excluded from test coverage - check `package.json` test script for exclusion pattern
+- **Custom ESLint Rules**: Debug custom `test-rules/arrange-act-assert` rule in `src/utils/eslint/index.ts`
+- **E2E Test Locations**: Cypress tests in `src/e2e/cypress/`, Playwright in `src/e2e/playwright/` (non-standard)
+- **Test Environment**: Jest uses `jest-environment-jsdom` with custom setup in `jest.setup.ts`
+- **Turbopack Issues**: Dev server uses `--turbopack` flag - may cause different behavior than standard Next.js
+- **CSP Debugging**: Custom headers in `next.config.ts` may block resources - check console for CSP violations

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md
+
+This file provides guidance to agents when working with code in this repository.
+
+## Non-Obvious Project Patterns
+
+- **Custom ESLint Plugin**: Uses local `eslint-plugin-test-rules` from `src/utils/eslint/` - enforces AAA pattern in tests
+- **Mandatory AAA Comments**: All tests MUST include `// Arrange`, `// Act`, `// Assert` comments or builds fail
+- **Test Coverage Exclusion**: Matrix.component.tsx excluded from coverage via package.json script
+- **Custom Test Validation**: `jest.setup.ts` validates AAA pattern at runtime using `src/utils/test-utils.ts`
+- **Turbopack Development**: Uses `--turbopack` flag for dev server (non-standard Next.js setup)
+- **Component Naming**: Components use `.component.tsx` suffix (not standard React convention)
+- **Custom CSP Headers**: Allows `https://presentasjon.dfweb.no` for iframe embedding in `next.config.ts`
+- **Sanity Defaults**: Hardcoded fallback values in client config (projectId: "41s7iutf", dataset: "production")
+- **E2E Test Structure**: Cypress tests in `src/e2e/cypress/`, Playwright in `src/e2e/playwright/` (not standard locations)
+- **Custom Refresh Script**: `pnpm refresh` does full cleanup including store prune and lock file removal
+
+## Critical Commands
+
+- **Single Test**: `jest --testNamePattern="test name"` (no built-in script)
+- **Coverage**: `jest --coverage --collectCoverageFrom='src/components/**/*.{js,jsx,ts,tsx}' --collectCoverageFrom='!src/components/Animations/Matrix.component.{js,jsx,ts,tsx}'`
+- **E2E**: `start-test dev 3000 cypress:headless` (requires dev server running)
+- **Lighthouse Variants**: `lhci:perf`, `lhci:desktop` for specific performance testing
+
+## Testing Gotchas
+
+- AAA pattern enforced by both ESLint rule AND runtime validation in jest.setup.ts
+- Test files outside `src/e2e/` must follow AAA pattern or fail
+- Matrix component intentionally excluded from test coverage
+- Cypress and Playwright have different ESLint rule overrides

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ Sanity.io and Typescript.
   easier debugging
 - AI-friendly repository documentation with automated updates (Repomix with
   Github action workflow)
+- AI assistant guidance with AGENTS.md files for immediate productivity
+  - Main AGENTS.md with project-specific patterns and gotchas
+  - Mode-specific guidance in .roo/rules-{mode}/AGENTS.md for specialized workflows
 - Sanity image URL generation with automatic resizing via `@sanity/image-url`.
 - Efficient data fetching in `/prosjekter` using Next.js preloading,
   React.cache, and server-only patterns, this achieves a LCP of 0.18s, down with


### PR DESCRIPTION
- This provides essential documentation for agents working with the repository, highlighting non-obvious patterns, critical commands, and testing requirements that may not be immediately apparent.