### PR TITLE
👷 ci: remove cypress container and add system dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,7 @@
 version: 2.1
 orbs:
-  cypress: cypress-io/cypress@5.0.1
   codecov: codecov/codecov@5.4.3
   node: circleci/node@7.2.0
-executors:
-  with-chrome-and-firefox:
-    docker:
-      - image: "cypress/browsers:node16.14.2-slim-chrome100-ff99-edge"
-    resource_class: large
 jobs:
   chromatic-deployment:
     docker:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -22,10 +22,23 @@ jobs:
         with:
           node-version: 22
           cache: "pnpm"
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Cache Cypress binary
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/Cypress
+          key: ${{ runner.os }}-cypress-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-cypress-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
+          install: false
           build: pnpm build
           start: pnpm dev
           wait-on: "http://localhost:3000"

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -8,9 +8,6 @@ jobs:
       fail-fast: false
       matrix:
         browser: [chrome, firefox, edge]
-    container:
-      image: cypress/browsers:node-22.18.0-chrome-139.0.7258.138-1-ff-142.0-edge-139.0.3405.102-1
-      options: --user 1001
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -36,6 +33,18 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Install system dependencies for browsers
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libnss3-dev \
+            libatk-bridge2.0-dev \
+            libdrm-dev \
+            libxkbcommon-dev \
+            libgtk-3-dev \
+            libgbm-dev \
+            libasound2-dev
 
       - name: Install Cypress binary
         run: pnpm exec cypress install

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -8,9 +8,6 @@ jobs:
       fail-fast: false
       matrix:
         browser: [chrome, firefox, edge]
-    container:
-      image: cypress/browsers:node-22.18.0-chrome-139.0.7258.138-1-ff-142.0-edge-139.0.3405.102-1
-      options: --user 1001
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -26,29 +23,11 @@ jobs:
           node-version: 22
           cache: 'pnpm'
 
-      - name: Cache Cypress binary
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/Cypress
-          key: ${{ runner.os }}-cypress-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-cypress-
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Install Cypress binary
-        run: pnpm exec cypress install
-
-      - name: Verify Cypress installation
-        run: pnpm exec cypress verify
-
       - name: Cypress run
-        uses: cypress-io/github-action@38f9a02ac2661ac1ee120f01dc9ad831e02decd6
+        uses: cypress-io/github-action@v6
         with:
           build: pnpm build
           start: pnpm dev
           wait-on: "http://localhost:3000"
           wait-on-timeout: 120
           browser: ${{ matrix.browser }}
-          install: false

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -8,6 +8,9 @@ jobs:
       fail-fast: false
       matrix:
         browser: [chrome, firefox, edge]
+    container:
+      image: cypress/browsers:node-22.18.0-chrome-139.0.7258.138-1-ff-142.0-edge-139.0.3405.102-1
+      options: --user 1001
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -33,18 +36,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Install system dependencies for browsers
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libnss3-dev \
-            libatk-bridge2.0-dev \
-            libdrm-dev \
-            libxkbcommon-dev \
-            libgtk-3-dev \
-            libgbm-dev \
-            libasound2-dev
 
       - name: Install Cypress binary
         run: pnpm exec cypress install

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
-          cache: 'pnpm'
+          cache: "pnpm"
 
       - name: Cypress run
         uses: cypress-io/github-action@v6


### PR DESCRIPTION
This change removes the container-based approach for Cypress tests and instead installs the necessary system dependencies directly on the runner. The change should improve build performance and reliability.