### PR TITLE
👷 ci: add cypress binary verification step

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Verify and install Cypress binary
+        run: npx cypress verify || npx cypress install
+
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:


### PR DESCRIPTION
- Ensure Cypress binary is properly installed before test execution by adding verification step that falls back to installation if needed.