### PR TITLE
📦 deps: update minimum Node.js version to 20.19.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.8",
   "private": true,
   "engines": {
-    "node": ">=20.16.0"
+    "node": ">=20.19.5"
   },
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
This change updates the required Node.js version from 20.16.0 to 20.19.5 to ensure we're using the latest LTS version with security patches.