### PR TITLE
🔧 chore: configure renovate scheduling and pr limits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "security:openssf-scorecard"],
+  "schedule": ["before 6am on saturday"],
+  "timezone": "Europe/Oslo",
   "minimumReleaseAge": "7 days",
   "internalChecksFilter": "strict",
-  "ignorePresets": [":prHourlyLimit2", ":prConcurrentLimit20"],
+  "prHourlyLimit": 5,
+  "prConcurrentLimit": 10,
   "ignoreTests": true,
   "packageRules": [
     {


### PR DESCRIPTION
Add weekly Saturday schedule with Oslo timezone and adjust PR rate limits to 5 hourly and 10 concurrent instead of using presets.