### PR TITLE
🔧 chore: disable minimum release age requirement

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -4,7 +4,7 @@
 # Minimum Release Age: Packages must be at least 7 days old before installation
 # This prevents installing freshly compromised packages
 # Value is in minutes: 10080 = 7 days (7 * 24 * 60)
-minimum-release-age=10080
+# minimum-release-age=10080
 
 # Registry configuration (using default npm registry which supports release timestamps)
 registry=https://registry.npmjs.org/


### PR DESCRIPTION
Temporarily comment out the minimum-release-age setting in .npmrc to allow immediate installation of newly published packages without the 7-day waiting period restriction.