### PR TITLE
🐛 fix: prevent external target for internal anchor links

### DIFF
--- a/src/components/UI/Button.component.tsx
+++ b/src/components/UI/Button.component.tsx
@@ -37,7 +37,8 @@ const Button = ({
 }: IButtonProps) => {
   const Component = renderAs ?? "button";
   const isLink = renderAs === "a";
-  const targetLink = isLink ? "_blank" : undefined;
+  const isInternalAnchor = href?.startsWith("#");
+  const targetLink = isLink && !isInternalAnchor ? "_blank" : undefined;
 
   return (
     <Component


### PR DESCRIPTION
Only apply target="_blank" to external links, not internal anchor links that start with "#" to maintain proper navigation behavior.