### PR TITLE
♻️ refactor: remove redundant role attribute from main

### DIFF
--- a/src/app/prosjekter/page.tsx
+++ b/src/app/prosjekter/page.tsx
@@ -32,11 +32,7 @@ export default function Prosjekter() {
 
   return (
     <RootLayout>
-      <main
-        role="main"
-        aria-label="Innhold portefølje"
-        className="mt-32 bg-graybg"
-      >
+      <main aria-label="Innhold portefølje" className="mt-32 bg-graybg">
         <PageHeader>Prosjekter</PageHeader>
         <Suspense fallback={<RotatingLoader />}>
           <ProjectList />


### PR DESCRIPTION
The role="main" attribute is redundant on the `<main>` HTML element as it already has an implicit ARIA role of main.