### PR TITLE
🐛 fix: update project query to explicitly check published

### DIFF
--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -1,7 +1,7 @@
 import { defineQuery } from "next-sanity";
 
 export const projectsQuery = defineQuery(`
-  *[_type == "project" && published != false] | order(featureOrder asc) {
+  *[_type == "project" && published == true] | order(featureOrder asc) {
     id,
     name,
     description,


### PR DESCRIPTION
- Changed the project query filter from checking `published != false` to `published == true` for more explicit and reliable filtering of published projects.