### PR TITLE
🔧 chore: increase codecov target to 95%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,5 +2,5 @@ coverage:
   status:
     project:
       default:
-        target: 90.0
-        threshold: 20.0
+        target: 95.0
+        threshold: "20"


### PR DESCRIPTION
- Update code coverage target from 90% to 95% and normalize threshold value format to string for consistency with codecov configuration standards.