### PR TITLE
✏️ typo: remove unnecessary quotes from tailwind import

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,4 @@
-@import url("tailwindcss");
+@import "tailwindcss";
 
 @config '../../tailwind.config.ts';
 


### PR DESCRIPTION
Fix CSS import syntax by using single quotes instead of double quotes for consistency with the config import statement below.