### PR TITLE
✨ feat(sanity): add typed fetch helper with caching

### DIFF
--- a/sanity.cli.ts
+++ b/sanity.cli.ts
@@ -2,7 +2,7 @@ import { defineCliConfig } from "sanity/cli";
 
 export default defineCliConfig({
   api: {
-    projectId: "jgcz3b93",
+    projectId: "41s7iutf",
     dataset: "production",
   },
 });

--- a/src/__mocks__/sanity-client.ts
+++ b/src/__mocks__/sanity-client.ts
@@ -2,6 +2,8 @@ export const client = {
   fetch: jest.fn().mockResolvedValue([]),
 };
 
+export const sanityFetch = jest.fn().mockResolvedValue(null);
+
 export function urlFor() {
   const imageUrlBuilder = {
     width: () => imageUrlBuilder,

--- a/src/__tests__/Prosjekter/actions.test.ts
+++ b/src/__tests__/Prosjekter/actions.test.ts
@@ -1,12 +1,9 @@
 import { getProjects } from "@/app/prosjekter/actions";
-import { client } from "@/lib/sanity/client";
-import { projectsQuery } from "@/lib/sanity/queries";
+import { sanityFetch } from "@/lib/sanity/client";
 
 // Mock the Sanity client
 jest.mock("@/lib/sanity/client", () => ({
-  client: {
-    fetch: jest.fn(),
-  },
+  sanityFetch: jest.fn(),
 }));
 
 describe("getProjects", () => {
@@ -27,21 +24,17 @@ describe("getProjects", () => {
         urlgithub: [],
       },
     ];
-    const expectedFetchOptions = {
-      next: { revalidate: 3600 },
-    };
-    (client.fetch as jest.Mock).mockResolvedValueOnce(mockProjects);
+    (sanityFetch as jest.Mock).mockResolvedValueOnce(mockProjects);
 
     // Act
     const result = await getProjects();
 
     // Assert
     expect(result).toStrictEqual(mockProjects);
-    expect(client.fetch).toHaveBeenCalledWith(
-      projectsQuery,
-      {},
-      expectedFetchOptions,
-    );
+    expect(sanityFetch).toHaveBeenCalledWith({
+      query: expect.any(String),
+      revalidate: 3600,
+    });
   });
 
   describe("error handling", () => {
@@ -55,7 +48,7 @@ describe("getProjects", () => {
           description: "Invalid token provided",
         },
       };
-      (client.fetch as jest.Mock).mockRejectedValueOnce(error);
+      (sanityFetch as jest.Mock).mockRejectedValueOnce(error);
 
       // Act & Assert
       await expect(getProjects()).rejects.toThrow("Authentication failed");
@@ -71,7 +64,7 @@ describe("getProjects", () => {
           description: "Missing read access",
         },
       };
-      (client.fetch as jest.Mock).mockRejectedValueOnce(error);
+      (sanityFetch as jest.Mock).mockRejectedValueOnce(error);
 
       // Act & Assert
       await expect(getProjects()).rejects.toThrow("Insufficient permissions");
@@ -84,7 +77,7 @@ describe("getProjects", () => {
         message: "Too Many Requests",
         details: { type: "rate_limit", description: "Rate limit exceeded" },
       };
-      (client.fetch as jest.Mock).mockRejectedValueOnce(error);
+      (sanityFetch as jest.Mock).mockRejectedValueOnce(error);
 
       // Act & Assert
       await expect(getProjects()).rejects.toThrow("Rate limit exceeded");
@@ -100,7 +93,7 @@ describe("getProjects", () => {
           description: "Syntax error in GROQ query",
         },
       };
-      (client.fetch as jest.Mock).mockRejectedValueOnce(error);
+      (sanityFetch as jest.Mock).mockRejectedValueOnce(error);
 
       // Act & Assert
       await expect(getProjects()).rejects.toThrow(
@@ -113,7 +106,7 @@ describe("getProjects", () => {
       const error = Object.assign(new Error("Network timeout"), {
         name: "TimeoutError",
       });
-      (client.fetch as jest.Mock).mockRejectedValueOnce(error);
+      (sanityFetch as jest.Mock).mockRejectedValueOnce(error);
 
       // Act & Assert
       await expect(getProjects()).rejects.toThrow("Request timed out");
@@ -124,7 +117,7 @@ describe("getProjects", () => {
       const error = {
         message: "Fetch failed",
       };
-      (client.fetch as jest.Mock).mockRejectedValueOnce(error);
+      (sanityFetch as jest.Mock).mockRejectedValueOnce(error);
 
       // Act & Assert
       await expect(getProjects()).rejects.toThrow("Failed to fetch projects");
@@ -150,9 +143,9 @@ describe("getProjects", () => {
       ];
 
       // First call fails with rate limit
-      (client.fetch as jest.Mock).mockRejectedValueOnce(rateError);
+      (sanityFetch as jest.Mock).mockRejectedValueOnce(rateError);
       // Second call succeeds
-      (client.fetch as jest.Mock).mockResolvedValueOnce(mockProjects);
+      (sanityFetch as jest.Mock).mockResolvedValueOnce(mockProjects);
 
       // First call should fail
       await expect(getProjects()).rejects.toThrow("Rate limit exceeded");

--- a/src/app/cv/page.tsx
+++ b/src/app/cv/page.tsx
@@ -1,7 +1,9 @@
+import { notFound } from "next/navigation";
 import CVContent from "@/components/CV/CVContent.component";
 
-import { client } from "@/lib/sanity/client";
+import { sanityFetch } from "@/lib/sanity/client";
 import { cvQuery } from "@/lib/sanity/queries";
+import type { Cv } from "@/types/sanity.types";
 
 import { Metadata } from "next/types";
 
@@ -10,7 +12,12 @@ export const metadata: Metadata = {
 };
 
 export default async function CVPage() {
-  const cvData = await client.fetch(cvQuery);
+  const cvData = await sanityFetch<Cv | null>({
+    query: cvQuery,
+    revalidate: 3600,
+  });
+
+  if (!cvData) notFound();
 
   return <CVContent cvData={cvData} />;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,8 +6,9 @@ import { SpeedInsights } from "@vercel/speed-insights/next";
 import "./globals.css";
 import "./glitch.css";
 
-import { client } from "@/lib/sanity/client";
+import { sanityFetch } from "@/lib/sanity/client";
 import { navigationQuery, settingsQuery } from "@/lib/sanity/queries";
+import type { Navigation, Settings } from "@/types/sanity.types";
 import LazyMotionProvider from "@/lib/framer/LazyMotionProvider";
 
 import SkipLink from "@/components/UI/SkipLink.component";
@@ -30,10 +31,12 @@ export default async function RootLayout({
   // Preconnect to Sanity CDN for faster image/data loading (Rule 6.10)
   preconnect("https://cdn.sanity.io");
 
-  const [navigation, { footerCopyrightText }] = await Promise.all([
-    client.fetch(navigationQuery),
-    client.fetch(settingsQuery),
+  const [navigation, settings] = await Promise.all([
+    sanityFetch<Navigation>({ query: navigationQuery, revalidate: 3600 }),
+    sanityFetch<Settings>({ query: settingsQuery, revalidate: 3600 }),
   ]);
+
+  const footerCopyrightText = settings?.footerCopyrightText;
 
   return (
     <html lang="nb">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,9 @@
 import dynamic from "next/dynamic";
-import { client } from "@/lib/sanity/client";
+import { notFound } from "next/navigation";
+import { sanityFetch } from "@/lib/sanity/client";
 import { pageContentQuery } from "@/lib/sanity/queries";
 import ContentLoader from "@/components/UI/ContentLoader.component";
+import type { Page } from "@/types/sanity.types";
 
 const DynamicHero = dynamic(() => import("@/components/Index/Hero.component"), {
   loading: () => <ContentLoader type="hero" />,
@@ -15,7 +17,12 @@ const DynamicIndexContent = dynamic(
 );
 
 export default async function HomePage() {
-  const pageContent = await client.fetch(pageContentQuery);
+  const pageContent = await sanityFetch<Page | null>({
+    query: pageContentQuery,
+    revalidate: 3600,
+  });
+
+  if (!pageContent) notFound();
 
   return (
     <main>

--- a/src/app/prosjekter/actions.ts
+++ b/src/app/prosjekter/actions.ts
@@ -1,20 +1,17 @@
 import { cache } from "react";
 import "server-only";
 
-import { client } from "@/lib/sanity/client";
+import { sanityFetch } from "@/lib/sanity/client";
 import { projectsQuery } from "@/lib/sanity/queries";
 
 import type { Project } from "@/types/sanity.types";
 import { isSanityApiError } from "@/types/sanity-errors";
 
 async function fetchProjectsFromSanity(): Promise<Project[]> {
-  return client.fetch(
-    projectsQuery,
-    {},
-    {
-      next: { revalidate: 3600 },
-    },
-  );
+  return sanityFetch<Project[]>({
+    query: projectsQuery,
+    revalidate: 3600,
+  });
 }
 
 function handleError(error: unknown): never {

--- a/src/lib/sanity/client.ts
+++ b/src/lib/sanity/client.ts
@@ -1,10 +1,10 @@
 import { createImageUrlBuilder } from "@sanity/image-url";
-import { createClient } from "@sanity/client";
+import { createClient, type QueryParams } from "@sanity/client";
 import type { Project } from "@/types/sanity.types";
 
 const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || "41s7iutf";
 const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET || "production";
-const apiVersion = process.env.NEXT_PUBLIC_SANITY_API_VERSION || "2023-05-03";
+const apiVersion = process.env.NEXT_PUBLIC_SANITY_API_VERSION || "2026-05-01";
 
 export const client = createClient({
   projectId,
@@ -12,6 +12,29 @@ export const client = createClient({
   apiVersion,
   useCdn: true,
 });
+
+/**
+ * Typed fetch helper with consistent caching defaults.
+ * Applies time-based revalidation (default 3600s) or tag-based invalidation.
+ */
+export async function sanityFetch<T>({
+  query,
+  params = {},
+  revalidate = 3600,
+  tags = [],
+}: {
+  query: string;
+  params?: QueryParams;
+  revalidate?: number | false;
+  tags?: string[];
+}): Promise<T> {
+  return client.fetch<T>(query, params, {
+    next: {
+      revalidate: tags.length ? false : revalidate,
+      tags,
+    },
+  });
+}
 
 const builder = createImageUrlBuilder(client);
 

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -56,7 +56,7 @@ export const cvQuery = defineQuery(`
 `);
 
 export const pageContentQuery = defineQuery(`
-  *[_type == 'page' && title match 'Hjem'][0]{
+  *[_type == 'page' && slug.current == 'hjem'][0]{
     "id": _id,
     title,
     hero,

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -56,7 +56,7 @@ export const cvQuery = defineQuery(`
 `);
 
 export const pageContentQuery = defineQuery(`
-  *[_type == 'page' && slug.current == 'hjem'][0]{
+  *[_type == 'page' && (slug.current == 'hjem' || title == 'Hjem')] | order(defined(slug.current) desc)[0]{
     "id": _id,
     title,
     hero,

--- a/studio/schemaTypes/documents/cv.ts
+++ b/studio/schemaTypes/documents/cv.ts
@@ -1,11 +1,15 @@
+import {defineType, defineField, defineArrayMember} from 'sanity'
+import {RiFileList3Line} from 'react-icons/ri'
+
 interface PreviewSelection {
   keyQualifications?: string[]
 }
 
-export default {
+export default defineType({
   name: 'cv',
   title: 'CV',
   type: 'document',
+  icon: RiFileList3Line,
   preview: {
     select: {
       keyQualifications: 'keyQualifications',
@@ -21,84 +25,84 @@ export default {
     },
   },
   fields: [
-    {
+    defineField({
       name: 'keyQualifications',
       title: 'Key Qualifications',
       type: 'array',
-      of: [{type: 'text'}],
-    },
-    {
+      of: [defineArrayMember({type: 'text'})],
+    }),
+    defineField({
       name: 'experience',
       title: 'Experience',
       type: 'array',
       of: [
-        {
+        defineArrayMember({
           type: 'object',
           fields: [
-            {name: 'period', title: 'Period', type: 'string'},
-            {
+            defineField({name: 'period', title: 'Period', type: 'string'}),
+            defineField({
               name: 'company',
               title: 'Company/Project',
               type: 'string',
               description: 'Company name or personal project/community name',
-            },
-            {
+            }),
+            defineField({
               name: 'role',
               title: 'Role',
               type: 'string',
               description: 'Job title or role in the project/community',
-            },
-            {name: 'description', title: 'Description', type: 'text'},
+            }),
+            defineField({name: 'description', title: 'Description', type: 'text'}),
           ],
-        },
+        }),
       ],
-    },
-    {
+    }),
+    defineField({
       name: 'education',
       title: 'Education',
       type: 'array',
       of: [
-        {
+        defineArrayMember({
           type: 'object',
           fields: [
-            {name: 'period', title: 'Period', type: 'string'},
-            {name: 'institution', title: 'Institution', type: 'string'},
-            {name: 'degree', title: 'Degree', type: 'string'},
-            {name: 'description', title: 'Description', type: 'text'},
+            defineField({name: 'period', title: 'Period', type: 'string'}),
+            defineField({name: 'institution', title: 'Institution', type: 'string'}),
+            defineField({name: 'degree', title: 'Degree', type: 'string'}),
+            defineField({name: 'description', title: 'Description', type: 'text'}),
           ],
-        },
+        }),
       ],
-    },
-    {
+    }),
+    defineField({
       name: 'volunteerWork',
       title: 'Volunteer work',
       type: 'array',
       of: [
-        {
+        defineArrayMember({
           type: 'object',
           fields: [
-            {name: 'period', title: 'Period', type: 'string'},
-            {
+            defineField({name: 'period', title: 'Period', type: 'string'}),
+            defineField({
               name: 'organization',
               title: 'Organization',
               type: 'string',
               description: 'Name of the community or organization',
-            },
-            {
+            }),
+            defineField({
               name: 'role',
               title: 'Role',
               type: 'string',
               description: 'Your role in the community',
-            },
-            {
+            }),
+            defineField({
               name: 'description',
               title: 'Description',
               type: 'text',
               description: 'Describe your contributions and impact',
-            },
+            }),
           ],
-        },
+        }),
       ],
-    },
+    }),
   ],
-}
+})

--- a/studio/schemaTypes/documents/navigation.ts
+++ b/studio/schemaTypes/documents/navigation.ts
@@ -6,7 +6,7 @@ import {
   RiGithubLine,
   RiMailLine,
 } from 'react-icons/ri'
-import {defineField, defineType, StringRule, BooleanRule} from 'sanity'
+import {defineField, defineType, defineArrayMember, StringRule, BooleanRule} from 'sanity'
 
 const iconMap = {
   RiHome4Line,
@@ -36,7 +36,7 @@ export default defineType({
       title: 'Navigation Links',
       type: 'array',
       of: [
-        {
+        defineArrayMember({
           type: 'object',
           fields: [
             defineField({
@@ -100,7 +100,7 @@ export default defineType({
               }
             },
           },
-        },
+        }),
       ],
     }),
   ],

--- a/studio/schemaTypes/documents/page.ts
+++ b/studio/schemaTypes/documents/page.ts
@@ -1,5 +1,5 @@
 import {RiPagesLine} from 'react-icons/ri'
-import {defineField, defineType, SchemaTypeDefinition} from 'sanity'
+import {defineField, defineType, defineArrayMember, SchemaTypeDefinition} from 'sanity'
 
 const page: SchemaTypeDefinition = defineType({
   title: 'Page',
@@ -13,6 +13,17 @@ const page: SchemaTypeDefinition = defineType({
       type: 'string',
     }),
     defineField({
+      title: 'Slug',
+      name: 'slug',
+      type: 'slug',
+      description: 'URL-friendly identifier for this page',
+      options: {
+        source: 'title',
+        maxLength: 96,
+      },
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
       title: 'Header',
       name: 'header',
       type: 'string',
@@ -22,7 +33,7 @@ const page: SchemaTypeDefinition = defineType({
       description: 'Only supported in Hjem/Index page',
       name: 'hero',
       type: 'array',
-      of: [{type: 'herocontent'}],
+      of: [defineArrayMember({type: 'herocontent'})],
       hidden: ({document}) => document?.title !== 'Hjem',
       validation: (Rule) => Rule.max(3),
     }),
@@ -31,7 +42,7 @@ const page: SchemaTypeDefinition = defineType({
       description: 'Only supported in Hjem/Index page',
       name: 'content',
       type: 'array',
-      of: [{type: 'pagecontent'}],
+      of: [defineArrayMember({type: 'pagecontent'})],
       hidden: ({document}) => document?.title !== 'Hjem',
     }),
   ],

--- a/studio/schemaTypes/documents/project.ts
+++ b/studio/schemaTypes/documents/project.ts
@@ -1,5 +1,5 @@
 import {RiEraserLine} from 'react-icons/ri'
-import {defineField, defineType} from 'sanity'
+import {defineField, defineType, defineArrayMember} from 'sanity'
 
 const project = defineType({
   title: 'Project',
@@ -51,18 +51,30 @@ const project = defineType({
       title: 'Project URL',
       name: 'urlwww',
       type: 'array',
-      of: [{type: 'link'}],
+      of: [defineArrayMember({type: 'link'})],
     }),
     defineField({
       title: 'Github URL',
       name: 'urlgithub',
       type: 'array',
-      of: [{type: 'link'}],
+      of: [defineArrayMember({type: 'link'})],
     }),
     defineField({
       title: 'Project image',
       name: 'projectimage',
       type: 'image',
+      options: {
+        hotspot: true,
+      },
+      fields: [
+        defineField({
+          name: 'alt',
+          type: 'string',
+          title: 'Alternative Text',
+          description: 'Describe the image for screen readers and SEO',
+          validation: (rule) => rule.warning('Alt text is important for accessibility and SEO'),
+        }),
+      ],
     }),
     defineField({
       title: 'Visible on Site',

--- a/studio/schemaTypes/objects/pagecontent.ts
+++ b/studio/schemaTypes/objects/pagecontent.ts
@@ -1,37 +1,29 @@
 import {RiArticleLine} from 'react-icons/ri'
+import {defineType, defineField, defineArrayMember} from 'sanity'
 
-const pagecontent = {
-  // This is the display name for the type
+const pagecontent = defineType({
   title: 'Page content',
-
-  // The identifier for this document type used in the api's
   name: 'pagecontent',
-
   icon: RiArticleLine,
-
-  // Documents have the type 'document'. Your schema may describe types beyond documents
-  // but let's get back to that later.
   type: 'object',
-
-  // Now we proceed to list the fields of our document
   fields: [
-    {
+    defineField({
       title: 'Id',
       name: 'id',
       type: 'number',
-    },
-    {
+    }),
+    defineField({
       title: 'Title',
       name: 'title',
       type: 'string',
-    },
-    {
+    }),
+    defineField({
       title: 'Text',
       name: 'text',
       type: 'array',
-      of: [{type: 'block'}],
-    },
+      of: [defineArrayMember({type: 'block'})],
+    }),
   ],
-}
+})
 
 export default pagecontent


### PR DESCRIPTION
- Introduces a new sanityFetch helper function that provides type-safe queries with built-in Next.js caching support. Supports both
time-based revalidation (default 1 hour) and tag-based cache invalidation. 
- Updates Sanity API version to 2026-05-01.
- Change Sanity project ID to point to the correct project instance.