### PR TITLE
♿️ access: remove WCAG contrast rule exception

### DIFF
--- a/.pa11yci.json
+++ b/.pa11yci.json
@@ -7,7 +7,7 @@
       "width": 1280,
       "height": 800
     },
-    "ignore": ["WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail"],
+    "ignore": [],
     "chromeLaunchConfig": {
       "args": ["--no-sandbox"]
     }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -3,12 +3,12 @@ import Pill from "@/components/UI/Pill.component";
 
 export default function Custom404() {
   return (
-    <div className="absolute w-full h-full">
+    <main className="absolute w-full h-full">
       <ReactMatrixAnimation />
       <div className="absolute inset-0 flex flex-col items-center justify-center h-full">
         <h1 className="text-white text-5xl m-6">Har du gått deg vill, Neo?</h1>
         <Pill href="/" text="Returner til Matrix" />
       </div>
-    </div>
+    </main>
   );
 }


### PR DESCRIPTION
- Remove the ignored WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail rule from pa11y configuration to enforce proper color contrast standards across the application.
- Improve semantic HTML structure in 404 page by replacing the root div wrapper with a main element for better accessibility
and adherence to HTML5 standards.