### PR TITLE
♿️ access: add WAI-ARIA keyboard navigation to tabs

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: "http://127.0.0.1:3000",
+    baseURL: "http://localhost:3000",
     //baseURL: 'https://www.dfweb.no',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */

--- a/src/__tests__/UI/Tabs.test.tsx
+++ b/src/__tests__/UI/Tabs.test.tsx
@@ -4,6 +4,7 @@
 
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import Tabs from "@/components/UI/Tabs.component";
 
@@ -40,6 +41,24 @@ const mockTabs = [
     id: "tab2",
     label: "Crashing Tab",
     content: <ImmediateCrash />,
+  },
+];
+
+const keyboardTestTabs = [
+  {
+    id: "tab1",
+    label: "First Tab",
+    content: <div>First content</div>,
+  },
+  {
+    id: "tab2",
+    label: "Second Tab",
+    content: <div>Second content</div>,
+  },
+  {
+    id: "tab3",
+    label: "Third Tab",
+    content: <div>Third content</div>,
   },
 ];
 
@@ -141,5 +160,177 @@ describe("Tabs", () => {
       expectedAttributes.labelledBy,
     );
     expect(activePanel).toHaveClass(expectedAttributes.className);
+  });
+});
+
+describe("Tabs Keyboard Navigation (WAI-ARIA APG)", () => {
+  const renderKeyboardTabs = (orientation?: "horizontal" | "vertical") =>
+    render(<Tabs tabs={keyboardTestTabs} orientation={orientation} />);
+
+  it("sets tabIndex=0 on active tab and tabIndex=-1 on inactive tabs", () => {
+    // Arrange
+    renderKeyboardTabs();
+
+    // Act
+    const tabs = screen.getAllByRole("tab");
+
+    // Assert
+    expect(tabs[0]).toHaveAttribute("tabIndex", "0");
+    expect(tabs[1]).toHaveAttribute("tabIndex", "-1");
+    expect(tabs[2]).toHaveAttribute("tabIndex", "-1");
+  });
+
+  it("moves focus to next tab on ArrowDown in vertical orientation", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    renderKeyboardTabs("vertical");
+    const tabs = screen.getAllByRole("tab");
+
+    // Act
+    tabs[0].focus();
+    await user.keyboard("{ArrowDown}");
+
+    // Assert
+    expect(tabs[1]).toHaveFocus();
+    expect(tabs[1]).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("moves focus to previous tab on ArrowUp in vertical orientation", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    renderKeyboardTabs("vertical");
+    const tabs = screen.getAllByRole("tab");
+
+    // Act
+    tabs[0].focus();
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{ArrowUp}");
+
+    // Assert
+    expect(tabs[0]).toHaveFocus();
+    expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("moves focus to next tab on ArrowRight in horizontal orientation", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    renderKeyboardTabs("horizontal");
+    const tabs = screen.getAllByRole("tab");
+
+    // Act
+    tabs[0].focus();
+    await user.keyboard("{ArrowRight}");
+
+    // Assert
+    expect(tabs[1]).toHaveFocus();
+    expect(tabs[1]).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("moves focus to previous tab on ArrowLeft in horizontal orientation", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    renderKeyboardTabs("horizontal");
+    const tabs = screen.getAllByRole("tab");
+
+    // Act
+    tabs[0].focus();
+    await user.keyboard("{ArrowRight}");
+    await user.keyboard("{ArrowLeft}");
+
+    // Assert
+    expect(tabs[0]).toHaveFocus();
+    expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("wraps focus from last tab to first tab on ArrowDown", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    renderKeyboardTabs("vertical");
+    const tabs = screen.getAllByRole("tab");
+
+    // Act
+    tabs[2].focus();
+    fireEvent.click(tabs[2]);
+    await user.keyboard("{ArrowDown}");
+
+    // Assert
+    expect(tabs[0]).toHaveFocus();
+    expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("wraps focus from first tab to last tab on ArrowUp", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    renderKeyboardTabs("vertical");
+    const tabs = screen.getAllByRole("tab");
+
+    // Act
+    tabs[0].focus();
+    await user.keyboard("{ArrowUp}");
+
+    // Assert
+    expect(tabs[2]).toHaveFocus();
+    expect(tabs[2]).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("moves focus to first tab on Home key", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    renderKeyboardTabs("vertical");
+    const tabs = screen.getAllByRole("tab");
+
+    // Act
+    tabs[0].focus();
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{Home}");
+
+    // Assert
+    expect(tabs[0]).toHaveFocus();
+    expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("moves focus to last tab on End key", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    renderKeyboardTabs("vertical");
+    const tabs = screen.getAllByRole("tab");
+
+    // Act
+    tabs[0].focus();
+    await user.keyboard("{End}");
+
+    // Assert
+    expect(tabs[2]).toHaveFocus();
+    expect(tabs[2]).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("sets aria-orientation on the tablist", () => {
+    // Arrange & Act
+    renderKeyboardTabs("vertical");
+    const tablist = screen.getByRole("tablist");
+
+    // Assert
+    expect(tablist).toHaveAttribute("aria-orientation", "vertical");
+  });
+
+  it("sets aria-orientation to horizontal when orientation is horizontal", () => {
+    // Arrange & Act
+    renderKeyboardTabs("horizontal");
+    const tablist = screen.getByRole("tablist");
+
+    // Assert
+    expect(tablist).toHaveAttribute("aria-orientation", "horizontal");
+  });
+
+  it("tab panel is focusable with tabIndex=0", () => {
+    // Arrange
+    renderKeyboardTabs();
+
+    // Act
+    const tabpanel = screen.getByRole("tabpanel");
+
+    // Assert
+    expect(tabpanel).toHaveAttribute("tabIndex", "0");
   });
 });

--- a/src/components/UI/Tabs.component.tsx
+++ b/src/components/UI/Tabs.component.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useRef, useCallback } from "react";
 import { AnimatePresence, LazyMotion, domMax } from "motion/react";
 import * as m from "motion/react-m";
 
@@ -24,6 +24,9 @@ interface TabButtonProps {
   index: number;
   totalTabs: number;
   onClick: () => void;
+  tabIndex: number;
+  buttonRef: (el: HTMLButtonElement | null) => void;
+  onKeyDown: (e: React.KeyboardEvent<HTMLButtonElement>) => void;
 }
 
 const getTabButtonClassName = (
@@ -52,15 +55,21 @@ const TabButton: React.FC<TabButtonProps> = ({
   index,
   totalTabs,
   onClick,
+  tabIndex,
+  buttonRef,
+  onKeyDown,
 }) => (
   <m.button
     key={tab.id}
+    ref={buttonRef}
     onClick={onClick}
+    onKeyDown={onKeyDown}
     className={getTabButtonClassName(isActive, isVertical, index, totalTabs)}
     role="tab"
     aria-selected={isActive}
     aria-controls={`tabpanel-${tab.id}`}
     id={`tab-${tab.id}`}
+    tabIndex={tabIndex}
   >
     {isActive && (
       <m.div
@@ -89,6 +98,7 @@ const TabPanel: React.FC<{ tab: Tab; isActive: boolean }> = ({
       id={`tabpanel-${tab.id}`}
       aria-labelledby={`tab-${tab.id}`}
       className="px-8"
+      tabIndex={0}
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: -20 }}
@@ -101,6 +111,11 @@ const TabPanel: React.FC<{ tab: Tab; isActive: boolean }> = ({
 
 /**
  * Renders a set of tabs with content.
+ * Implements WAI-ARIA APG Tabs Pattern keyboard navigation:
+ * - Arrow Left/Up: Move to previous tab
+ * - Arrow Right/Down: Move to next tab
+ * - Home: Move to first tab
+ * - End: Move to last tab
  *
  * @param {TabsProps} props - The props object containing the tabs and orientation.
  * @param {Tab[]} props.tabs - An array of Tab objects representing the tabs.
@@ -110,6 +125,58 @@ const TabPanel: React.FC<{ tab: Tab; isActive: boolean }> = ({
 const Tabs: React.FC<TabsProps> = ({ tabs, orientation = "vertical" }) => {
   const [activeTab, setActiveTab] = useState(() => tabs[0]?.id ?? "");
   const isVertical = orientation === "vertical";
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const setTabRef = useCallback(
+    (index: number) => (el: HTMLButtonElement | null) => {
+      tabRefs.current[index] = el;
+    },
+    [],
+  );
+
+  const focusTab = useCallback(
+    (index: number) => {
+      const tab = tabs[index];
+      if (tab) {
+        setActiveTab(tab.id);
+        tabRefs.current[index]?.focus();
+      }
+    },
+    [tabs],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+      const prevKey = isVertical ? "ArrowUp" : "ArrowLeft";
+      const nextKey = isVertical ? "ArrowDown" : "ArrowRight";
+
+      let newIndex: number | null = null;
+
+      switch (e.key) {
+        case nextKey:
+          e.preventDefault();
+          newIndex = (index + 1) % tabs.length;
+          break;
+        case prevKey:
+          e.preventDefault();
+          newIndex = (index - 1 + tabs.length) % tabs.length;
+          break;
+        case "Home":
+          e.preventDefault();
+          newIndex = 0;
+          break;
+        case "End":
+          e.preventDefault();
+          newIndex = tabs.length - 1;
+          break;
+      }
+
+      if (newIndex !== null) {
+        focusTab(newIndex);
+      }
+    },
+    [tabs.length, isVertical, focusTab],
+  );
 
   return (
     <LazyMotion features={domMax}>
@@ -127,6 +194,7 @@ const Tabs: React.FC<TabsProps> = ({ tabs, orientation = "vertical" }) => {
             <div
               className={`flex ${isVertical ? "flex-row sm:flex-col" : "flex-row"}`}
               role="tablist"
+              aria-orientation={isVertical ? "vertical" : "horizontal"}
             >
               {tabs.map((tab, index) => (
                 <TabButton
@@ -137,6 +205,9 @@ const Tabs: React.FC<TabsProps> = ({ tabs, orientation = "vertical" }) => {
                   index={index}
                   totalTabs={tabs.length}
                   onClick={() => setActiveTab(tab.id)}
+                  tabIndex={activeTab === tab.id ? 0 : -1}
+                  buttonRef={setTabRef(index)}
+                  onKeyDown={(e) => handleKeyDown(e, index)}
                 />
               ))}
             </div>

--- a/src/e2e/playwright/cv.spec.ts
+++ b/src/e2e/playwright/cv.spec.ts
@@ -36,3 +36,98 @@ test.describe("CV page", () => {
     );
   });
 });
+
+test.describe("CV page — Tabs keyboard navigation (WAI-ARIA APG)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/cv");
+  });
+
+  test("navigates tabs with ArrowDown key in vertical orientation", async ({
+    page,
+  }) => {
+    const firstTab = page.getByRole("tab", { name: "Nøkkelkvalifikasjoner" });
+    const secondTab = page.getByRole("tab", { name: "Erfaring" });
+
+    // Focus the first tab
+    await firstTab.focus();
+    await expect(firstTab).toBeFocused();
+
+    // Press ArrowDown to move to the next tab
+    await page.keyboard.press("ArrowDown");
+    await expect(secondTab).toBeFocused();
+    await expect(secondTab).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("navigates tabs with ArrowUp key in vertical orientation", async ({
+    page,
+  }) => {
+    const firstTab = page.getByRole("tab", { name: "Nøkkelkvalifikasjoner" });
+    const secondTab = page.getByRole("tab", { name: "Erfaring" });
+
+    // Focus the second tab by clicking it first, then use keyboard
+    await secondTab.click();
+    await secondTab.focus();
+
+    // Press ArrowUp to move to the previous tab
+    await page.keyboard.press("ArrowUp");
+    await expect(firstTab).toBeFocused();
+    await expect(firstTab).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("wraps from last tab to first tab on ArrowDown", async ({ page }) => {
+    const firstTab = page.getByRole("tab", { name: "Nøkkelkvalifikasjoner" });
+    const tabs = page.getByRole("tab");
+    const lastTab = tabs.last();
+
+    // Click and focus the last tab
+    await lastTab.click();
+    await lastTab.focus();
+
+    // Press ArrowDown should wrap to first tab
+    await page.keyboard.press("ArrowDown");
+    await expect(firstTab).toBeFocused();
+    await expect(firstTab).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("Home key moves focus to first tab", async ({ page }) => {
+    const firstTab = page.getByRole("tab", { name: "Nøkkelkvalifikasjoner" });
+    const secondTab = page.getByRole("tab", { name: "Erfaring" });
+
+    // Click the second tab, then press Home
+    await secondTab.click();
+    await secondTab.focus();
+    await page.keyboard.press("Home");
+
+    await expect(firstTab).toBeFocused();
+    await expect(firstTab).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("End key moves focus to last tab", async ({ page }) => {
+    const firstTab = page.getByRole("tab", { name: "Nøkkelkvalifikasjoner" });
+    const tabs = page.getByRole("tab");
+    const lastTab = tabs.last();
+
+    // Focus the first tab, then press End
+    await firstTab.focus();
+    await page.keyboard.press("End");
+
+    await expect(lastTab).toBeFocused();
+    await expect(lastTab).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("tablist has aria-orientation attribute", async ({ page }) => {
+    const tablist = page.getByRole("tablist");
+    await expect(tablist).toHaveAttribute("aria-orientation", "vertical");
+  });
+
+  test("only active tab has tabIndex=0, inactive tabs have tabIndex=-1", async ({
+    page,
+  }) => {
+    const firstTab = page.getByRole("tab", { name: "Nøkkelkvalifikasjoner" });
+    const secondTab = page.getByRole("tab", { name: "Erfaring" });
+
+    // First tab is active by default
+    await expect(firstTab).toHaveAttribute("tabindex", "0");
+    await expect(secondTab).toHaveAttribute("tabindex", "-1");
+  });
+});


### PR DESCRIPTION
- Implement full keyboard navigation support following WAI-ARIA APG Tabs Pattern. Add arrow key navigation (Left/Right for horizontal, Up/Down for vertical), Home/End keys, focus management with roving tabindex, and proper ARIA attributes including aria-orientation.