### PR TITLE
📝 docs: update docstrings to follow PEP 257 style

### DIFF
--- a/commit/commit_analyzer.py
+++ b/commit/commit_analyzer.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-AI-Powered Git Commit Message Generator
+"""AI-Powered Git Commit Message Generator.
 
 Generates conventional commit messages using OpenAI, Anthropic, or any OpenAI-compatible LLM API.
 
@@ -80,9 +79,7 @@ def _filter_diff_excluding_paths(diff: str, excluded_paths: List[str]) -> str:
 
 
 def _run_git_command(args: List[str]) -> str:
-    """
-    Safely execute a git command with strict whitelist validation.
-    """
+    """Safely execute a git command with strict whitelist validation."""
     if not args:
         raise ValueError("Git command arguments cannot be empty")
 
@@ -120,11 +117,12 @@ def _is_lock_file(filename: str) -> bool:
 
 
 def get_staged_diff() -> Tuple[Optional[str], bool, List[str]]:
-    """
-    Get the diff of staged changes and list of changed files.
+    """Get the diff of staged changes and list of changed files.
 
-    Returns:
+    Returns
+    -------
         Tuple of (diff_content, has_lock_files, changed_files)
+
     """
     try:
         files_output = _run_git_command(["diff", _GIT_ARG_CACHED, _GIT_ARG_NAME_ONLY])

--- a/commit/providers/__init__.py
+++ b/commit/providers/__init__.py
@@ -1,5 +1,4 @@
-"""
-Provider abstraction layer for LLM API integrations.
+"""Provider abstraction layer for LLM API integrations.
 
 This module provides a unified interface for interacting with different LLM providers
 (OpenAI, Anthropic, and OpenAI-compatible endpoints) through a common API.

--- a/commit/providers/anthropic_provider.py
+++ b/commit/providers/anthropic_provider.py
@@ -1,6 +1,4 @@
-"""
-Anthropic provider implementation using the official Anthropic Python SDK.
-"""
+"""Anthropic provider implementation using the official Anthropic Python SDK."""
 
 import os
 from typing import Optional
@@ -11,8 +9,7 @@ from providers.base import BaseProvider
 
 
 class AnthropicProvider(BaseProvider):
-    """
-    Provider implementation for Anthropic's API.
+    """Provider implementation for Anthropic's API.
 
     Uses the official Anthropic Python SDK to interact with Claude models.
 
@@ -24,14 +21,16 @@ class AnthropicProvider(BaseProvider):
     DEFAULT_MODEL = "claude-sonnet-4-5-20250929"
 
     def __init__(self, api_key: Optional[str] = None):
-        """
-        Initialize the Anthropic provider.
+        """Initialize the Anthropic provider.
 
-        Args:
+        Args
+        ----
             api_key: Optional API key. If not provided, reads from ANTHROPIC_API_KEY env var.
 
-        Raises:
+        Raises
+        ------
             ValueError: If no API key is found.
+
         """
         self._api_key = api_key or os.getenv("ANTHROPIC_API_KEY")
         if not self._api_key:

--- a/commit/providers/base.py
+++ b/commit/providers/base.py
@@ -1,14 +1,11 @@
-"""
-Base provider abstract class defining the interface all LLM providers must implement.
-"""
+"""Base provider abstract class defining the interface all LLM providers must implement."""
 
 from abc import ABC, abstractmethod
 from typing import Optional
 
 
 class BaseProvider(ABC):
-    """
-    Abstract base class for LLM providers.
+    """Abstract base class for LLM providers.
     
     All provider implementations must inherit from this class and implement
     the required abstract methods to ensure a consistent interface.
@@ -17,31 +14,33 @@ class BaseProvider(ABC):
     @property
     @abstractmethod
     def name(self) -> str:
-        """
-        Return the provider name (e.g., 'openai', 'anthropic', 'openai-compatible').
-        """
+        """Return the provider name (e.g., 'openai', 'anthropic', 'openai-compatible')."""
 
     @abstractmethod
     def chat_completion(self, prompt: str, model: Optional[str] = None) -> str:
-        """
-        Send a chat completion request and return the response text.
+        """Send a chat completion request and return the response text.
         
-        Args:
+        Args
+        ----
             prompt: The user prompt to send to the LLM.
             model: Optional model override. If not provided, uses the default model.
             
-        Returns:
+        Returns
+        -------
             The text response from the LLM.
             
-        Raises:
+        Raises
+        ------
             Exception: If the API request fails.
+
         """
 
     @abstractmethod
     def get_default_model(self) -> str:
-        """
-        Return the default model for this provider.
+        """Return the default model for this provider.
         
-        Returns:
+        Returns
+        -------
             The default model identifier string.
+
         """

--- a/commit/providers/factory.py
+++ b/commit/providers/factory.py
@@ -1,5 +1,4 @@
-"""
-Provider factory with auto-detection and explicit selection support.
+"""Provider factory with auto-detection and explicit selection support.
 
 This module provides a factory function to get the appropriate LLM provider
 based on environment configuration.
@@ -27,8 +26,7 @@ class InvalidProviderError(Exception):
 
 
 def get_provider(provider_name: Optional[str] = None) -> BaseProvider:
-    """
-    Get an LLM provider instance.
+    """Get an LLM provider instance.
 
     If provider_name is specified, returns that specific provider.
     Otherwise, checks the PROVIDER environment variable.
@@ -39,15 +37,19 @@ def get_provider(provider_name: Optional[str] = None) -> BaseProvider:
     2. OpenAI (if OPENAI_API_KEY is set)
     3. OpenAI-compatible (if OPENAI_COMPATIBLE_API_KEY and OPENAI_COMPATIBLE_BASE_URL are set)
 
-    Args:
+    Args
+    ----
         provider_name: Optional explicit provider name ('anthropic', 'openai', 'openai-compatible').
 
-    Returns:
+    Returns
+    -------
         A configured provider instance.
 
-    Raises:
+    Raises
+    ------
         InvalidProviderError: If an invalid provider name is specified.
         ProviderConfigurationError: If no provider can be configured.
+
     """
     # Determine provider name
     name = provider_name or os.getenv("PROVIDER")

--- a/commit/providers/factory.py
+++ b/commit/providers/factory.py
@@ -68,14 +68,16 @@ def get_provider(provider_name: Optional[str] = None) -> BaseProvider:
 
 
 def _create_provider(name: str) -> BaseProvider:
-    """
-    Create a provider instance by name.
+    """Create a provider instance by name.
 
-    Args:
+    Args
+    ----
         name: The provider name.
 
-    Returns:
+    Returns
+    -------
         A configured provider instance.
+
     """
     if name == "anthropic":
         return AnthropicProvider()
@@ -88,14 +90,16 @@ def _create_provider(name: str) -> BaseProvider:
 
 
 def _auto_detect_provider() -> BaseProvider:
-    """
-    Auto-detect and return the appropriate provider based on available API keys.
+    """Auto-detect and return the appropriate provider based on available API keys.
 
-    Returns:
+    Returns
+    -------
         A configured provider instance.
 
-    Raises:
+    Raises
+    ------
         ProviderConfigurationError: If no API keys are found.
+
     """
     # Check for Anthropic (highest priority)
     if os.getenv("ANTHROPIC_API_KEY"):

--- a/commit/providers/openai_compatible.py
+++ b/commit/providers/openai_compatible.py
@@ -1,5 +1,4 @@
-"""
-Generic OpenAI-compatible provider implementation.
+"""Generic OpenAI-compatible provider implementation.
 
 This provider supports any API endpoint that implements the OpenAI API format,
 such as LM Studio, Ollama, vLLM, and other local or self-hosted LLM services.
@@ -14,8 +13,7 @@ from providers.base import BaseProvider
 
 
 class OpenAICompatibleProvider(BaseProvider):
-    """
-    Provider implementation for OpenAI-compatible APIs.
+    """Provider implementation for OpenAI-compatible APIs.
 
     Uses the OpenAI Python SDK with a custom base_url to interact with
     any OpenAI-compatible endpoint.
@@ -31,15 +29,17 @@ class OpenAICompatibleProvider(BaseProvider):
         api_key: Optional[str] = None,
         base_url: Optional[str] = None,
     ):
-        """
-        Initialize the OpenAI-compatible provider.
+        """Initialize the OpenAI-compatible provider.
 
-        Args:
+        Args
+        ----
             api_key: Optional API key. If not provided, reads from OPENAI_COMPATIBLE_API_KEY env var.
             base_url: Optional base URL. If not provided, reads from OPENAI_COMPATIBLE_BASE_URL env var.
 
-        Raises:
+        Raises
+        ------
             ValueError: If API key or base URL is not found.
+
         """
         self._api_key = api_key or os.getenv("OPENAI_COMPATIBLE_API_KEY")
         self._base_url = base_url or os.getenv("OPENAI_COMPATIBLE_BASE_URL")

--- a/commit/providers/openai_provider.py
+++ b/commit/providers/openai_provider.py
@@ -1,6 +1,4 @@
-"""
-OpenAI provider implementation using the official OpenAI Python SDK.
-"""
+"""OpenAI provider implementation using the official OpenAI Python SDK."""
 
 import os
 from typing import Optional
@@ -11,8 +9,7 @@ from providers.base import BaseProvider
 
 
 class OpenAIProvider(BaseProvider):
-    """
-    Provider implementation for OpenAI's API.
+    """Provider implementation for OpenAI's API.
 
     Uses the official OpenAI Python SDK to interact with GPT models.
 
@@ -24,14 +21,16 @@ class OpenAIProvider(BaseProvider):
     DEFAULT_MODEL = "gpt-5.2"
 
     def __init__(self, api_key: Optional[str] = None):
-        """
-        Initialize the OpenAI provider.
+        """Initialize the OpenAI provider.
 
-        Args:
+        Args
+        ----
             api_key: Optional API key. If not provided, reads from OPENAI_API_KEY env var.
 
-        Raises:
+        Raises
+        ------
             ValueError: If no API key is found.
+
         """
         self._api_key = api_key or os.getenv("OPENAI_API_KEY")
         if not self._api_key:


### PR DESCRIPTION
- Convert multi-line docstrings to use single-line format where appropriate and standardize Returns section formatting to use
numpydoc style with proper section headers and formatting.