### PR TITLE
🎨 style: format docstrings to single-line style

### DIFF
--- a/commit/commit_analyzer.py
+++ b/commit/commit_analyzer.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-AI-Powered Git Commit Message Generator.
+"""AI-Powered Git Commit Message Generator.
 
 Generates conventional commit messages using OpenAI, Anthropic, or any OpenAI-compatible LLM API.
 
@@ -118,13 +117,11 @@ def _is_lock_file(filename: str) -> bool:
 
 
 def get_staged_diff() -> Tuple[Optional[str], bool, List[str]]:
-    """
-    Get the diff of staged changes and list of changed files.
+    """Get the diff of staged changes and list of changed files.
 
     Returns
     -------
         Tuple of (diff_content, has_lock_files, changed_files)
-
     """
     try:
         files_output = _run_git_command(["diff", _GIT_ARG_CACHED, _GIT_ARG_NAME_ONLY])

--- a/commit/providers/anthropic_provider.py
+++ b/commit/providers/anthropic_provider.py
@@ -10,6 +10,7 @@ from providers.base import BaseProvider
 
 
 class AnthropicProvider(BaseProvider):
+
     """Provider implementation for Anthropic's API.
 
     Uses the official Anthropic Python SDK to interact with Claude models.

--- a/commit/providers/anthropic_provider.py
+++ b/commit/providers/anthropic_provider.py
@@ -1,6 +1,5 @@
-"""
-Anthropic provider implementation using the official Anthropic Python SDK.
-"""
+"""Anthropic provider implementation using the official Anthropic Python
+SDK."""
 
 import os
 from typing import Optional
@@ -11,8 +10,7 @@ from providers.base import BaseProvider
 
 
 class AnthropicProvider(BaseProvider):
-    """
-    Provider implementation for Anthropic's API.
+    """Provider implementation for Anthropic's API.
 
     Uses the official Anthropic Python SDK to interact with Claude models.
 
@@ -24,8 +22,7 @@ class AnthropicProvider(BaseProvider):
     DEFAULT_MODEL = "claude-sonnet-4-5-20250929"
 
     def __init__(self, api_key: Optional[str] = None):
-        """
-        Initialize the Anthropic provider.
+        """Initialize the Anthropic provider.
 
         Args
         ----
@@ -34,7 +31,6 @@ class AnthropicProvider(BaseProvider):
         Raises
         ------
             ValueError: If no API key is found.
-
         """
         self._api_key = api_key or os.getenv("ANTHROPIC_API_KEY")
         if not self._api_key:
@@ -53,8 +49,7 @@ class AnthropicProvider(BaseProvider):
         return os.getenv("MODEL_NAME", self.DEFAULT_MODEL)
 
     def chat_completion(self, prompt: str, model: Optional[str] = None) -> str:
-        """
-        Send a chat completion request to Anthropic.
+        """Send a chat completion request to Anthropic.
 
         Args
         ----
@@ -64,7 +59,6 @@ class AnthropicProvider(BaseProvider):
         Returns
         -------
             The text response from the model.
-
         """
         model_to_use = model or self.get_default_model()
 

--- a/commit/providers/base.py
+++ b/commit/providers/base.py
@@ -1,51 +1,47 @@
-"""
-Base provider abstract class defining the interface all LLM providers must implement.
-"""
+"""Base provider abstract class defining the interface all LLM providers must
+implement."""
 
 from abc import ABC, abstractmethod
 from typing import Optional
 
 
 class BaseProvider(ABC):
-    """
-    Abstract base class for LLM providers.
-    
-    All provider implementations must inherit from this class and implement
-    the required abstract methods to ensure a consistent interface.
+    """Abstract base class for LLM providers.
+
+    All provider implementations must inherit from this class and
+    implement the required abstract methods to ensure a consistent
+    interface.
     """
 
     @property
     @abstractmethod
     def name(self) -> str:
-        """Return the provider name (e.g., 'openai', 'anthropic', 'openai-compatible')."""
+        """Return the provider name (e.g., 'openai', 'anthropic', 'openai-
+        compatible')."""
 
     @abstractmethod
     def chat_completion(self, prompt: str, model: Optional[str] = None) -> str:
-        """
-        Send a chat completion request and return the response text.
-        
+        """Send a chat completion request and return the response text.
+
         Args
         ----
             prompt: The user prompt to send to the LLM.
             model: Optional model override. If not provided, uses the default model.
-            
+
         Returns
         -------
             The text response from the LLM.
-            
+
         Raises
         ------
             Exception: If the API request fails.
-
         """
 
     @abstractmethod
     def get_default_model(self) -> str:
-        """
-        Return the default model for this provider.
-        
+        """Return the default model for this provider.
+
         Returns
         -------
             The default model identifier string.
-
         """

--- a/commit/providers/base.py
+++ b/commit/providers/base.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 
 class BaseProvider(ABC):
+
     """Abstract base class for LLM providers.
 
     All provider implementations must inherit from this class and
@@ -16,7 +17,7 @@ class BaseProvider(ABC):
     @property
     @abstractmethod
     def name(self) -> str:
-        """Return the provider name."""
+        """Get the provider name."""
 
     @abstractmethod
     def chat_completion(self, prompt: str, model: Optional[str] = None) -> str:

--- a/commit/providers/base.py
+++ b/commit/providers/base.py
@@ -16,8 +16,7 @@ class BaseProvider(ABC):
     @property
     @abstractmethod
     def name(self) -> str:
-        """Return the provider name (e.g., 'openai', 'anthropic', 'openai-
-        compatible')."""
+        """Return the provider name."""
 
     @abstractmethod
     def chat_completion(self, prompt: str, model: Optional[str] = None) -> str:

--- a/commit/providers/factory.py
+++ b/commit/providers/factory.py
@@ -18,10 +18,12 @@ VALID_PROVIDERS = frozenset(["anthropic", "openai", "openai-compatible"])
 
 
 class ProviderConfigurationError(Exception):
+
     """Raised when provider configuration is invalid or missing."""
 
 
 class InvalidProviderError(Exception):
+
     """Raised when an invalid provider name is specified."""
 
 

--- a/commit/providers/factory.py
+++ b/commit/providers/factory.py
@@ -1,8 +1,7 @@
-"""
-Provider factory with auto-detection and explicit selection support.
+"""Provider factory with auto-detection and explicit selection support.
 
-This module provides a factory function to get the appropriate LLM provider
-based on environment configuration.
+This module provides a factory function to get the appropriate LLM
+provider based on environment configuration.
 """
 
 import os
@@ -27,8 +26,7 @@ class InvalidProviderError(Exception):
 
 
 def get_provider(provider_name: Optional[str] = None) -> BaseProvider:
-    """
-    Get an LLM provider instance.
+    """Get an LLM provider instance.
 
     If provider_name is specified, returns that specific provider.
     Otherwise, checks the PROVIDER environment variable.
@@ -51,7 +49,6 @@ def get_provider(provider_name: Optional[str] = None) -> BaseProvider:
     ------
         InvalidProviderError: If an invalid provider name is specified.
         ProviderConfigurationError: If no provider can be configured.
-
     """
     # Determine provider name
     name = provider_name or os.getenv("PROVIDER")
@@ -70,8 +67,7 @@ def get_provider(provider_name: Optional[str] = None) -> BaseProvider:
 
 
 def _create_provider(name: str) -> BaseProvider:
-    """
-    Create a provider instance by name.
+    """Create a provider instance by name.
 
     Args
     ----
@@ -80,7 +76,6 @@ def _create_provider(name: str) -> BaseProvider:
     Returns
     -------
         A configured provider instance.
-
     """
     if name == "anthropic":
         return AnthropicProvider()
@@ -93,8 +88,8 @@ def _create_provider(name: str) -> BaseProvider:
 
 
 def _auto_detect_provider() -> BaseProvider:
-    """
-    Auto-detect and return the appropriate provider based on available API keys.
+    """Auto-detect and return the appropriate provider based on available API
+    keys.
 
     Returns
     -------
@@ -103,7 +98,6 @@ def _auto_detect_provider() -> BaseProvider:
     Raises
     ------
         ProviderConfigurationError: If no API keys are found.
-
     """
     # Check for Anthropic (highest priority)
     if os.getenv("ANTHROPIC_API_KEY"):

--- a/commit/providers/openai_compatible.py
+++ b/commit/providers/openai_compatible.py
@@ -14,6 +14,7 @@ from providers.base import BaseProvider
 
 
 class OpenAICompatibleProvider(BaseProvider):
+
     """Provider implementation for OpenAI-compatible APIs.
 
     Uses the OpenAI Python SDK with a custom base_url to interact with

--- a/commit/providers/openai_compatible.py
+++ b/commit/providers/openai_compatible.py
@@ -1,8 +1,8 @@
-"""
-Generic OpenAI-compatible provider implementation.
+"""Generic OpenAI-compatible provider implementation.
 
-This provider supports any API endpoint that implements the OpenAI API format,
-such as LM Studio, Ollama, vLLM, and other local or self-hosted LLM services.
+This provider supports any API endpoint that implements the OpenAI API
+format, such as LM Studio, Ollama, vLLM, and other local or self-hosted
+LLM services.
 """
 
 import os
@@ -14,8 +14,7 @@ from providers.base import BaseProvider
 
 
 class OpenAICompatibleProvider(BaseProvider):
-    """
-    Provider implementation for OpenAI-compatible APIs.
+    """Provider implementation for OpenAI-compatible APIs.
 
     Uses the OpenAI Python SDK with a custom base_url to interact with
     any OpenAI-compatible endpoint.
@@ -31,8 +30,7 @@ class OpenAICompatibleProvider(BaseProvider):
         api_key: Optional[str] = None,
         base_url: Optional[str] = None,
     ):
-        """
-        Initialize the OpenAI-compatible provider.
+        """Initialize the OpenAI-compatible provider.
 
         Args
         ----
@@ -42,7 +40,6 @@ class OpenAICompatibleProvider(BaseProvider):
         Raises
         ------
             ValueError: If API key or base URL is not found.
-
         """
         self._api_key = api_key or os.getenv("OPENAI_COMPATIBLE_API_KEY")
         self._base_url = base_url or os.getenv("OPENAI_COMPATIBLE_BASE_URL")
@@ -66,8 +63,7 @@ class OpenAICompatibleProvider(BaseProvider):
         return "openai-compatible"
 
     def get_default_model(self) -> str:
-        """
-        Return the default model for this provider.
+        """Return the default model for this provider.
 
         Note: For OpenAI-compatible providers, the model must be specified
         via MODEL_NAME environment variable as there's no universal default.
@@ -81,8 +77,7 @@ class OpenAICompatibleProvider(BaseProvider):
         return model
 
     def chat_completion(self, prompt: str, model: Optional[str] = None) -> str:
-        """
-        Send a chat completion request to the OpenAI-compatible endpoint.
+        """Send a chat completion request to the OpenAI-compatible endpoint.
 
         Args
         ----
@@ -92,7 +87,6 @@ class OpenAICompatibleProvider(BaseProvider):
         Returns
         -------
             The text response from the model.
-
         """
         model_to_use = model or self.get_default_model()
 

--- a/commit/providers/openai_provider.py
+++ b/commit/providers/openai_provider.py
@@ -9,6 +9,7 @@ from providers.base import BaseProvider
 
 
 class OpenAIProvider(BaseProvider):
+
     """Provider implementation for OpenAI's API.
 
     Uses the official OpenAI Python SDK to interact with GPT models.

--- a/commit/providers/openai_provider.py
+++ b/commit/providers/openai_provider.py
@@ -1,6 +1,4 @@
-"""
-OpenAI provider implementation using the official OpenAI Python SDK.
-"""
+"""OpenAI provider implementation using the official OpenAI Python SDK."""
 
 import os
 from typing import Optional
@@ -11,8 +9,7 @@ from providers.base import BaseProvider
 
 
 class OpenAIProvider(BaseProvider):
-    """
-    Provider implementation for OpenAI's API.
+    """Provider implementation for OpenAI's API.
 
     Uses the official OpenAI Python SDK to interact with GPT models.
 
@@ -24,8 +21,7 @@ class OpenAIProvider(BaseProvider):
     DEFAULT_MODEL = "gpt-5.5"
 
     def __init__(self, api_key: Optional[str] = None):
-        """
-        Initialize the OpenAI provider.
+        """Initialize the OpenAI provider.
 
         Args
         ----
@@ -34,7 +30,6 @@ class OpenAIProvider(BaseProvider):
         Raises
         ------
             ValueError: If no API key is found.
-
         """
         self._api_key = api_key or os.getenv("OPENAI_API_KEY")
         if not self._api_key:
@@ -53,8 +48,7 @@ class OpenAIProvider(BaseProvider):
         return os.getenv("MODEL_NAME", self.DEFAULT_MODEL)
 
     def chat_completion(self, prompt: str, model: Optional[str] = None) -> str:
-        """
-        Send a chat completion request to OpenAI.
+        """Send a chat completion request to OpenAI.
 
         Args
         ----
@@ -64,7 +58,6 @@ class OpenAIProvider(BaseProvider):
         Returns
         -------
             The text response from the model.
-
         """
         model_to_use = model or self.get_default_model()
 


### PR DESCRIPTION
Update multi-line docstrings to single-line format where appropriate and ensure consistent formatting across all provider modules and base classes. Remove trailing blank lines in docstring sections.