### PR TITLE
🔥 cleanup: remove loader from matrix animation import

### DIFF
--- a/src/components/Index/Hero.component.tsx
+++ b/src/components/Index/Hero.component.tsx
@@ -6,7 +6,6 @@ import type { Herocontent } from "@/types/sanity.types";
 
 import Icons from "./Icons.component";
 import FadeIn from "../Animations/FadeIn.component";
-import RotatingLoader from "../Animations/RotatingLoader.component";
 import MobileBackground from "./MobileBackground.component";
 import MatrixCursor from "../Animations/MatrixCursor.component";
 
@@ -14,11 +13,6 @@ const ReactMatrixAnimation = dynamic(
   () => import("../Animations/Matrix.component"),
   {
     ssr: false,
-    loading: () => (
-      <div className="text-center">
-        <RotatingLoader />
-      </div>
-    ),
   },
 );
 


### PR DESCRIPTION
Remove unnecessary RotatingLoader component and its loading state from the dynamic import of ReactMatrixAnimation. The loading indicator is no longer needed for this component.