### PR TITLE
📝 docs: remove niquests reference from pin-actions description

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Sanity.io and Typescript.
   - All workflow action references pinned to immutable commit SHAs (not mutable tags or branches)
   - Prevents tag-rewriting attacks (e.g. tj-actions/changed-files compromise)
   - Original version preserved as trailing comment for readability (`@<sha> # v6`)
-  - Custom audit script at `scripts/pin-actions.py` (uses `niquests` for secure HTTPS)
+  - Custom audit script at `scripts/pin-actions.py`
     - `python scripts/pin-actions.py audit` — scan and report mutable references
     - `python scripts/pin-actions.py verify` — CI gate (exit 1 if any unpinned)
     - `python scripts/pin-actions.py pin` — resolve tags/branches to SHAs and rewrite workflow files


### PR DESCRIPTION
Update README to drop outdated mention of niquests dependency in the action pinning audit script description.