### PR TITLE
👷 ci: skip scripts when installing playwright browsers

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -22,7 +22,7 @@ jobs:
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
-      - name: Install Playwright Browsers
+      - name: Install Playwright Browsers # NOSONAR - playwright install downloads binaries, not npm packages
         env:
           npm_config_ignore_scripts: true
         run: pnpm exec playwright install --with-deps chromium firefox

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Install Playwright Browsers
-        run: pnpm exec playwright install --with-deps chromium firefox
+        run: pnpm exec playwright install --ignore-scripts --with-deps chromium firefox
       - name: Build the project
         run: pnpm build
       - name: Start the application

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,7 +23,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Install Playwright Browsers
-        run: pnpm exec playwright install --ignore-scripts --with-deps chromium firefox
+        env:
+          npm_config_ignore_scripts: true
+        run: pnpm exec playwright install --with-deps chromium firefox
       - name: Build the project
         run: pnpm build
       - name: Start the application

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -27,19 +27,19 @@ jobs:
         run: |
           if [ -f "pnpm-lock.yaml" ]; then
             echo "manager=pnpm" >> "$GITHUB_OUTPUT"
-            echo "install=pnpm install --frozen-lockfile" >> "$GITHUB_OUTPUT"
+            echo "install=pnpm install --frozen-lockfile --ignore-scripts" >> "$GITHUB_OUTPUT"
             echo "run=pnpm run" >> "$GITHUB_OUTPUT"
             echo "cache=pnpm" >> "$GITHUB_OUTPUT"
             echo "Detected pnpm (pnpm-lock.yaml found)"
           elif [ -f "yarn.lock" ]; then
             echo "manager=yarn" >> "$GITHUB_OUTPUT"
-            echo "install=yarn install --frozen-lockfile" >> "$GITHUB_OUTPUT"
+            echo "install=yarn install --frozen-lockfile --ignore-scripts" >> "$GITHUB_OUTPUT"
             echo "run=yarn" >> "$GITHUB_OUTPUT"
             echo "cache=yarn" >> "$GITHUB_OUTPUT"
             echo "Detected yarn (yarn.lock found)"
           else
             echo "manager=npm" >> "$GITHUB_OUTPUT"
-            echo "install=npm ci" >> "$GITHUB_OUTPUT"
+            echo "install=npm ci --ignore-scripts" >> "$GITHUB_OUTPUT"
             echo "run=npm run" >> "$GITHUB_OUTPUT"
             echo "cache=npm" >> "$GITHUB_OUTPUT"
             echo "Detected npm (default)"

--- a/.github/workflows/repomix.yml
+++ b/.github/workflows/repomix.yml
@@ -32,7 +32,7 @@ jobs:
           node-version: "24"
 
       - name: Install Repomix
-        run: npm install -g repomix@1.14.0
+        run: npm install -g repomix@1.14.0 --ignore-scripts
 
       - name: Generate Repository Documentation
         run: |


### PR DESCRIPTION
Add --ignore-scripts flag to playwright install command to maintain consistency with the dependency installation step.