### PR TITLE
🔧 chore: target modern browsers with explicit version thresholds

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,7 +1,6 @@
-# Modern browsers that support all baseline features
-# This eliminates unnecessary polyfills for Array.prototype.at, flat, flatMap, etc.
->0.2% and not dead and not op_mini all
-last 2 Chrome versions
-last 2 Firefox versions
-last 2 Safari versions
-last 2 Edge versions
+# Target only modern browsers that support ES2022+ features
+# Eliminates polyfills for Array.prototype.at, flat, flatMap, Object.fromEntries, etc.
+chrome >= 92
+firefox >= 90
+safari >= 15.4
+edge >= 92

--- a/.swcrc
+++ b/.swcrc
@@ -1,0 +1,24 @@
+{
+  "jsc": {
+    "parser": {
+      "syntax": "typescript",
+      "tsx": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "react": {
+        "runtime": "automatic"
+      }
+    },
+    "target": "es2022"
+  },
+  "env": {
+    "targets": {
+      "chrome": "92",
+      "firefox": "90",
+      "safari": "15.4",
+      "edge": "92"
+    },
+    "mode": "usage"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -90,5 +90,11 @@
     "ts-jest": "^29.4.9",
     "typescript": "^6.0.3",
     "wait-on": "^9.1.0"
-  }
+  },
+  "browserslist": [
+    "chrome >= 92",
+    "firefox >= 90",
+    "safari >= 15.4",
+    "edge >= 92"
+  ]
 }


### PR DESCRIPTION
Replace percentage-based browserslist query with explicit minimum versions for Chrome, Firefox, Safari, and Edge to ensure ES2022+ support and eliminate unnecessary polyfills.