### PR TITLE
🔥 cleanup: remove unused browserslist configuration

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,6 +1,0 @@
-# Target only modern browsers that support ES2022+ features
-# Eliminates polyfills for Array.prototype.at, flat, flatMap, Object.fromEntries, etc.
-chrome >= 92
-firefox >= 90
-safari >= 15.4
-edge >= 92


### PR DESCRIPTION
Delete .browserslistrc as target browser support is now handled elsewhere, removing redundant config file